### PR TITLE
added soft reset command to use when switching RAT

### DIFF
--- a/walter-modem/src/WalterModem.cpp
+++ b/walter-modem/src/WalterModem.cpp
@@ -3731,6 +3731,12 @@ bool WalterModem::sendCmd(const char *cmd)
         WALTER_MODEM_CMD_TYPE_TX) != NULL;
 }
 
+bool WalterModem::softReset(WalterModemRsp *rsp, walterModemCb cb, void *args)
+{
+    _runCmd({"AT^RESET"}, "+SYSSTART", rsp, cb, args);
+    _returnAfterReply();
+}
+
 bool WalterModem::reset(WalterModemRsp *rsp, walterModemCb cb, void *args)
 {
     _runCmd({}, "+SYSSTART", rsp, cb, args, NULL, NULL,

--- a/walter-modem/src/WalterModem.h
+++ b/walter-modem/src/WalterModem.h
@@ -2961,7 +2961,25 @@ class WalterModem
          * @return True on success, false otherwise.
          */
         static bool sendCmd(const char *cmd);
-
+        
+        /**
+         * @brief Software reset the modem and wait for it to reset. All
+         * connections will not be lost. (required when switching RAT) The function
+         * will fail when the modem doesn't reset.
+         *
+         * @param rsp Pointer to a modem response structure to save the result
+         * of the command in. When NULL is given the result is ignored.
+         * @param cb Optional callback argument, when not NULL this function
+         * will return immediately.
+         * @param args Optional argument to pass to the callback.
+         *
+         * @return True on success, false otherwise.
+         */
+        static bool softReset(
+            WalterModemRsp *rsp = NULL,
+            walterModemCb cb = NULL,
+            void *args = NULL);
+        
         /**
          * @brief Physically reset the modem and wait for it to start. All 
          * connections will be lost when this function is called. The function

--- a/walter-modem/src/WalterModem.h
+++ b/walter-modem/src/WalterModem.h
@@ -2963,9 +2963,9 @@ class WalterModem
         static bool sendCmd(const char *cmd);
         
         /**
-         * @brief Software reset the modem and wait for it to reset. All
-         * connections will not be lost. (required when switching RAT) The function
-         * will fail when the modem doesn't reset.
+         * @brief Software reset the modem and wait for it to reset. 
+         * (required when switching RAT) 
+         * The function will fail when the modem doesn't reset.
          *
          * @param rsp Pointer to a modem response structure to save the result
          * of the command in. When NULL is given the result is ignored.


### PR DESCRIPTION
this adds a soft reset to use when switching RAT so you don't need to hardware reset the modem everytime.