### PR TITLE
Wait for event functionality

### DIFF
--- a/examples/socket_test/main/socket_test.cpp
+++ b/examples/socket_test/main/socket_test.cpp
@@ -53,7 +53,9 @@
 #include "WalterModem.h"
 
 void connected(WalterModemConnectionEventType event) {
-  ESP_LOGE("event", "connection event: %i",event);
+  if(event == WALTER_MODEM_CONNECTED) {
+    ESP_LOGE("event", "connection event: %i",event);
+  }
 }
 
 /**
@@ -191,7 +193,6 @@ extern "C" void app_main(void)
 
   /* Wait for the network to become available */
   modem.waitForConnectionEvent(WALTER_MODEM_CONNECTED);
-  ESP_LOGI("socket_test", "Connected to the network");
 
   /* Activate the PDP context */
   if(modem.setPDPContextActive(true)) {

--- a/examples/socket_test/main/socket_test.cpp
+++ b/examples/socket_test/main/socket_test.cpp
@@ -52,6 +52,10 @@
 #include <driver/uart.h>
 #include "WalterModem.h"
 
+void connected(WalterModemConnectionEventType event) {
+  ESP_LOGE("event", "connection event: %i",event);
+}
+
 /**
  * @brief The address of the server to upload the data to. 
  */
@@ -97,6 +101,12 @@ extern "C" void app_main(void)
   } else {
     ESP_LOGI("socket_test", "Modem initialization ERROR");
     return;
+  }
+  
+  if(modem.registerConnectionEventHandler(connected)){
+    ESP_LOGI("event", "succesfully registered handler");
+  } else {
+    ESP_LOGD("event", "could not register connection handler");
   }
 
   if(modem.checkComm()) {

--- a/examples/socket_test/main/socket_test.cpp
+++ b/examples/socket_test/main/socket_test.cpp
@@ -52,9 +52,10 @@
 #include <driver/uart.h>
 #include "WalterModem.h"
 
-void connected(WalterModemConnectionEventType event) {
-  if(event == WALTER_MODEM_CONNECTED) {
-    ESP_LOGE("event", "connection event: %i",event);
+void registrationEvent(WalterModemNetworkRegState state, void* args) {
+  if (state == WALTER_MODEM_NETWORK_REG_REGISTERED_HOME || state == WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING)
+  {
+    ESP_LOGE("event", "connection event: %i",state);
   }
 }
 
@@ -105,11 +106,8 @@ extern "C" void app_main(void)
     return;
   }
   
-  if(modem.registerConnectionEventHandler(connected)){
-    ESP_LOGI("event", "succesfully registered handler");
-  } else {
-    ESP_LOGD("event", "could not register connection handler");
-  }
+  modem.onRegistrationEvent(registrationEvent);
+
 
   if(modem.checkComm()) {
     ESP_LOGI("socket_test", "Modem communication is ok");
@@ -192,7 +190,10 @@ extern "C" void app_main(void)
   }
 
   /* Wait for the network to become available */
-  modem.waitForConnectionEvent(WALTER_MODEM_CONNECTED);
+  modem.waitForRegistrationEvent({
+    WALTER_MODEM_NETWORK_REG_REGISTERED_HOME,
+    WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING
+  });
 
   /* Activate the PDP context */
   if(modem.setPDPContextActive(true)) {

--- a/examples/socket_test/main/socket_test.cpp
+++ b/examples/socket_test/main/socket_test.cpp
@@ -180,13 +180,7 @@ extern "C" void app_main(void)
   }
 
   /* Wait for the network to become available */
-  WalterModemNetworkRegState regState = modem.getNetworkRegState();
-  while(!(regState == WALTER_MODEM_NETWORK_REG_REGISTERED_HOME ||
-          regState == WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING))
-  {
-    vTaskDelay(pdMS_TO_TICKS(100));
-    regState = modem.getNetworkRegState();
-  }
+  modem.waitForConnectionEvent(WALTER_MODEM_CONNECTED);
   ESP_LOGI("socket_test", "Connected to the network");
 
   /* Activate the PDP context */

--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -4045,6 +4045,15 @@ char WalterModem::_getLuhnChecksum(const char *imei)
     return (char) (((10 - (sum % 10)) % 10) + '0');
 }
 
+void WalterModem::_callConnectionEventHandlers(WalterModemConnectionEventType connectionEventType){
+    for (size_t i = 0; i < WALTER_MODEM_MAX_CONNECTION_EVENT_HANDLERS; i++) {
+        if(_connection_event_handlers[i]) {
+            _connection_event_handlers[i](connectionEventType);
+        }
+    }
+    
+}
+
 bool WalterModem::tlsProvisionKeys(
     const char *walterCertificate,
     const char *walterPrivateKey,

--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -5420,3 +5420,27 @@ bool WalterModem::performGNSSAction(
         gnssActionStr(action),"\""), "OK", rsp, cb, args);
     _returnAfterReply();
 }
+
+bool WalterModem::registerConnectionEventHandler(walterModemConnectionEventHandler handler) {
+    for (size_t i = 0; i < WALTER_MODEM_MAX_CONNECTION_EVENT_HANDLERS; i++) {
+        // handlers cannot be registered multiple times otherwise the same event handler function would be called multiple times.
+        if (_connection_event_handlers[i] == handler) {
+            return true
+        }
+        //check for empty index to store the eventHandler function into.
+        if (!_connection_event_handlers[i]) {
+            _connection_event_handlers[i] = handler;
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+void WalterModem::unregisterConnectionEventHandler(walterModemConnectionEventHandler handler) {
+    for (size_t i = 0; i < WALTER_MODEM_MAX_CONNECTION_EVENT_HANDLERS; i++) {
+        if (_connection_event_handlers[i] ==  handler) {
+            _connection_event_handlers[i] = nullptr;
+        }
+    }
+}

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -922,9 +922,9 @@ typedef enum {
  */
 typedef enum {
     /**
-     * @brief Connection related events.
+     * @brief Network registration related events.
      */
-    WALTER_MODEM_EVENT_TYPE_CONNECTION = 0,
+    WALTER_MODEM_EVENT_TYPE_REGISTRATION = 0,
 
     /**
      * @brief System related events.
@@ -943,22 +943,6 @@ typedef enum {
 } WalterModemEventType;
 
 /**
- * @brief This enumeration groups the different types of connection events.
- */
-typedef enum {
-    WALTER_MODEM_CONNECTION_EVENT_DISCONNECTED_NOT_SEARCHING,
-    WALTER_MODEM_CONNECTION_EVENT_SEARCHING,
-    WALTER_MODEM_CONNECTION_EVENT_REGISTRATION_DENIED,
-    WALTER_MODEM_CONNECTION_EVENT_REGISTERED_TEMPORARY_CONNECTION_LOST,
-    WALTER_MODEM_CONNECTION_EVENT_TEMPORARY_DI
-    WALTER_MODEM_CONNECTION_EVENT_REGISTERED_HOME,
-    WALTER_MODEM_CONNECTION_EVENT_REGISTERED_ROAMING,
-    WALTER_MODEM_CONNECTION_EVENT_REGISTERED_SMS_ONLY_HOME,
-    WALTER_MODEM_CONNECTION_EVENT_REGISTERED_SMS_ONLY_ROAMING,
-    WALTER_MODEM_CONNECTION_EVENT_ATTACHED_EMERGENCY_BEARER_ONLY
-} WalterModemConnectionEvent;
-
-/**
  * @brief This enumeration groups the different types of system events.
  */
 typedef enum {
@@ -966,14 +950,14 @@ typedef enum {
 } WalterModemSystemEvent;
 
 /**
- * @brief Header of a connection event handler.
+ * @brief Header of a network registration event handler.
  * 
- * @param ev The type of connection event.
+ * @param ev The new network registration state.
  * @param args Optional arguments set by the application layer.
  * 
  * @return None.
  */
-typedef void (*walterModemConnectionEventHandler)(WalterModemConnectionEvent ev, void *args);
+typedef void (*walterModemRegistrationEventHandler)(WalterModemNetworkRegState ev, void *args);
 
 /**
  * @brief Header of a system event handler.
@@ -4675,9 +4659,9 @@ class WalterModem
         static void offlineMotaUpgrade(uint8_t *otaBuffer);
 
         /**
-         * @brief Register a connection event handler.
+         * @brief Register a network registration event handler.
          * 
-         * This function will register an application layer connection event handler. If you want
+         * This function will register an application layer registration event handler. If you want
          * to explicitly de-register the handler for this type of event you can pass a nullptr to 
          * this function.
          * 
@@ -4686,7 +4670,7 @@ class WalterModem
          * 
          * @return None.
          */
-        static void onConnectionEvent(walterModemConnectionEventHandler handler = nullptr, void *args = nullptr);
+        static void onRegistrationEvent(walterModemRegistrationEventHandler handler = nullptr, void *args = nullptr);
 
         /**
          * @brief Register a system event handler.

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -229,6 +229,7 @@
  */
 #define SPI_FLASH_BLOCK_SIZE    (SPI_SECTORS_PER_BLOCK*SPI_FLASH_SEC_SIZE)
 
+#define WALTER_MODEM_MAX_CONNECTION_EVENT_HANDLERS 6
 /**
  * @brief This enum groups status codes of functions and operational components
  * of the modem.
@@ -916,6 +917,14 @@ typedef enum {
     WALTER_MODEM_BLUECHERRY_EVENT_TYPE_MOTA_FINISH = 7,
     WALTER_MODEM_BLUECHERRY_EVENT_TYPE_MOTA_ERROR = 8
 } WalterModemBlueCherryEventType;
+
+/**
+ * @brief the possible connection event types
+ */
+typedef enum {
+    WALTER_MODEM_CONNECTED,
+    WALTER_MODEM_LOST_CONNECTION,
+} WalterModemConnectionEventType
 
 /**
  * @brief This structure represents the 
@@ -2207,6 +2216,11 @@ struct WalterModemStpResponseTransferBlock
 };
 
 /**
+ * @brief callback used for modem connection events
+ */
+typedef void (*walterModemConnectionEventHandler)(const WalterModemConnectionEventType connectionEventType);
+
+/**
  * @brief The WalterModem class allows you to use the Sequans Monarch 2 modem
  * and positioning functionality.
  */
@@ -2425,6 +2439,11 @@ class WalterModem
          */
         static inline bool _rxHandlerInterrupted = false;
 
+        /**
+         * @brief array that holds all the connection event handlers.
+         */
+        static inline walterModemConnectionEventHandler _connection_event_handlers[WALTER_MODEM_MAX_CONNECTION_EVENT_HANDLERS]
+        
         /*
          * @brief Helper to boot modem to recovery modem and start upgrade
          */
@@ -2979,7 +2998,7 @@ class WalterModem
             WalterModemRsp *rsp = NULL,
             walterModemCb cb = NULL,
             void *args = NULL);
-        
+
         /**
          * @brief Physically reset the modem and wait for it to start. All 
          * connections will be lost when this function is called. The function
@@ -4548,6 +4567,11 @@ class WalterModem
          * expected to be at least SPI_FLASH_SEC_SIZE = 4K
          */
         static void offlineMotaUpgrade(uint8_t *otaBuffer);
-};
+        /**
+         * @brief registers a connection event handler
+         * @param handler walterModemConnectionEventHandler
+         */
+        static bool registerConnectionEventHandler(walterModemConnectionEventHandler handler);
+    };
 
 #endif

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -2894,6 +2894,13 @@ class WalterModem
          */
         static char _getLuhnChecksum(const char *imei);
 
+        /**
+         * @brief this function calls all the registerd eventHandler functions.
+         *
+         * @param connectionEventType the eventType to pass down tot the eventHandlers
+         */
+        static void _callConnectionEventHandlers(WalterModemConnectionEventType connectionEventType);
+        
     public:
         /**
          * @brief Initialize the modem.
@@ -4580,7 +4587,6 @@ class WalterModem
          */
         static void unregisterConnectionEventHandler(walterModemConnectionEventHandler handler);
 
-        
     };
 
 #endif

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -932,6 +932,7 @@ typedef enum : uint8_t {
  * @brief The posible event groups
  */
 typedef enum {
+    WALTER_MODEM_EVENT_GROUP_NONE,
     WALTER_MODEM_EVENT_GROUP_CONNECTION,
     WALTER_MODEM_EVENT_GROUP_AT,
 } WalterModemEventGroup;

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -2512,6 +2512,8 @@ class WalterModem
          */
         static inline WalterModemCmdLock _eventLock = {};
 
+        static inline int _currentEventSubType = 0;
+
         /*
          * @brief Helper to boot modem to recovery modem and start upgrade
          */
@@ -2979,10 +2981,10 @@ class WalterModem
         /**
          * @brief This function waits for a certain event to fire before returning
          * 
-         * @param group The group in wich the event is fired.
-         * @param eventType The type of the event that is being fired
+         * @param type The main type of event that is being fired.
+         * @param subTypes The subtypes of the event you want to wait for.
          */
-        static void _waitForEvent(WalterModemEventGroup group, uint8_t type);
+        static void _waitForEvent(WalterModemEventType type, std::initializer_list<int> subTypes);
 
     public:
         /**
@@ -4700,12 +4702,12 @@ class WalterModem
          */
         static void onATEvent(walterModemATEventHandler handler = nullptr, void *args = nullptr);
 
-        // /**
-        //  * @brief This function will wait for a connection event to fire of the specified type.
-        //  * 
-        //  * @param eventType The type of connection event you want to wait for.
-        //  */
-        // static void waitForConnectionEvent(WalterModemConnectionEventType eventType);
+        /**
+         * @brief This function will wait for a connection event to fire of the specified type.
+         *
+         * @param regStates as soon as one of the regstates is fired the function will return
+         */
+        static void waitForRegistrationEvent(std::initializer_list<WalterModemNetworkRegState> regStates);
     };
 
 #endif

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -4685,7 +4685,7 @@ class WalterModem
          * 
          * @return None.
          */
-        static void onConnectionEvent(walterModemConnectionEventHandler handler, void *args);
+        static void onConnectionEvent(walterModemConnectionEventHandler handler = nullptr, void *args = nullptr);
 
         /**
          * @brief Register a system event handler.
@@ -4699,7 +4699,7 @@ class WalterModem
          * 
          * @return None.
          */
-        static void onSystemEvent(walterModemSystemEventHandler handler, void *args);
+        static void onSystemEvent(walterModemSystemEventHandler handler = nullptr, void *args = nullptr);
 
         /**
          * @brief Register an AT event handler.
@@ -4713,7 +4713,7 @@ class WalterModem
          * 
          * @return None.
          */
-        static void onATEvent(walterModemATEventHandler handler, void *args);
+        static void onATEvent(walterModemATEventHandler handler = nullptr, void *args = nullptr);
 
         // /**
         //  * @brief This function will wait for a connection event to fire of the specified type.

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -2985,11 +2985,12 @@ class WalterModem
          * was registered for this specific event the function is a no-op.
          * 
          * @param type The type of event to dispatch.
-         * @param data Specific event info (enum or AT response string).
+         * @param subtype The event subtype specific to the type of event which is dispatched.
+         * @param data Specific event data.
          * 
          * @return None.
          */
-        static void _dispatchEvent(WalterModemEventType type, void *data);
+        static void _dispatchEvent(WalterModemEventType type, int subtype, void *data = nullptr);
         
         /**
          * @brief This function waits for a certain event to fire before returning

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -2512,6 +2512,8 @@ class WalterModem
          */
         static inline WalterModemCmdLock _eventLock = {};
 
+        static inline WalterModemEventType _currentEventType = WALTER_MODEM_EVENT_TYPE_COUNT;
+        
         static inline int _currentEventSubType = 0;
 
         /*
@@ -4703,11 +4705,18 @@ class WalterModem
         static void onATEvent(walterModemATEventHandler handler = nullptr, void *args = nullptr);
 
         /**
-         * @brief This function will wait for a connection event to fire of the specified type.
+         * @brief This function will wait for a registration event to fire.
          *
-         * @param regStates as soon as one of the regstates is fired the function will return
+         * @param regStates As soon as one of the provided regstates is reached the function will return
          */
         static void waitForRegistrationEvent(std::initializer_list<WalterModemNetworkRegState> regStates);
-    };
+
+        /**
+         * @brief This function will wait for a system event to fire.
+         * 
+         * @param systemStates As soon as one of the provided regstates is reached the function will return
+         */
+        static void waitForSystemEvent(std::initializer_list<WalterModemSystemEvent> systemStates);
+};
 
 #endif

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -4567,11 +4567,18 @@ class WalterModem
          * expected to be at least SPI_FLASH_SEC_SIZE = 4K
          */
         static void offlineMotaUpgrade(uint8_t *otaBuffer);
+
         /**
          * @brief registers a connection event handler
          * @param handler walterModemConnectionEventHandler
          */
         static bool registerConnectionEventHandler(walterModemConnectionEventHandler handler);
+        
+        /**
+         * @brief deregisters a connection event handler
+         * @param handler walterModemConnectionEventHandler
+         */
+        static void unregisterConnectionEventHandler(walterModemConnectionEventHandler handler);
     };
 
 #endif

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -4579,6 +4579,8 @@ class WalterModem
          * @param handler walterModemConnectionEventHandler
          */
         static void unregisterConnectionEventHandler(walterModemConnectionEventHandler handler);
+
+        
     };
 
 #endif

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -972,13 +972,13 @@ typedef void (*walterModemSystemEventHandler)(WalterModemSystemEvent ev, void *a
 /**
  * @brief Header of an AT event handler.
  * 
- * @param at_response A constant string which contains the AT response. Only valid memory during 
- * the lifetime of the event handler.
+ * @param len The number of valid bytes in the response buffer. 
+ * @param buff A buffer which contains the unparsed AT response data, not 0-terminated.
  * @param args Optional arguments set by the application layer.
  * 
  * @return None.
  */
-typedef void (*walterModemATEventHandler)(const char *at_response, void *args);
+typedef void (*walterModemATEventHandler)(size_t len, const char *buff, void *args);
 
 /**
  * @brief This structure represents an event handler and it's metadata.


### PR DESCRIPTION
pull request for @daanpape.

# TL;DR
currently there is a _waitForEvent() function, i think this is on the right track, but has some notable shortcommings with the [`std::initalizer_list<int>`](https://en.cppreference.com/w/cpp/utility/initializer_list):
- it cannot be cast (templates to the rescue?)

I do propose we use the std::initalizer_list instead of the va_args as it offers a much cleaner and performant solution.

The current state could be passed by reference, this way we can wait for any state we would want.

# proposal:
signature:

```cpp
template<typename T>
static void _waitForEvent(int timeout, WalterModemEventType type,T& currentState, std::initializer_list<T> subTypes);
```
This way the function can also potentialy be used externaly to, as you could just do the following:

```cpp
_waitForEvent(30,WALTER_MODEM_EVENT_TYPE_REGISTRATION,_regState,{
    WALTER_MODEM_NETWORK_REG_REGISTERED_HOME,
    WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING
});
```
# Helper functions

using the waitForEvent we could make helper functions, for example:
```cpp
void WalterModem::waitForRegistrationEvent(int timeout, std::initializer_list<WalterModemNetworkRegState> regStates) {
    return _waitForEvent(timeout,WALTER_MODEM_EVENT_TYPE_REGISTRATION,_regState,regStates);
}
```  
