### PR TITLE
Improve #60

### DIFF
--- a/examples/bluecherry/components/Bluecherry_ZTP/CMakeLists.txt
+++ b/examples/bluecherry/components/Bluecherry_ZTP/CMakeLists.txt
@@ -1,3 +1,6 @@
-idf_component_register(SRCS "./BlueCherryZTP.cpp
-                            "./BlueCherryZTP_CBOR.cp"
-            INCLUDE_DIRS ".")
+idf_component_register(SRCS "./BlueCherryZTP.cpp"
+                            "./BlueCherryZTP_CBOR.cpp"
+            INCLUDE_DIRS "."
+            PRIV_REQUIRES 
+        bootloader_support mbedtls walter-modem
+            )

--- a/examples/bluecherry/main/Kconfig.projbuild
+++ b/examples/bluecherry/main/Kconfig.projbuild
@@ -11,7 +11,7 @@ menu "Walter BlueCherry example"
             help
                 Set the BlueCherry Device type as found in the BlueApp.
         config BC_TLS_PROFILE
-            string "Modem TLS profile ID for BlueCherry"
+            int "Modem TLS profile ID for BlueCherry"
             default 1
             help
                 Specify what TLS profile ID the modem will use to configure TLS communication with BlueCherry.

--- a/examples/bluecherry/main/bluecherry_example.cpp
+++ b/examples/bluecherry/main/bluecherry_example.cpp
@@ -218,10 +218,17 @@ void syncBlueCherry()
                 ESP_LOGI(TAG, "Topic: %02x\r\n", rsp.data.blueCherry.messages[msgIdx].topic);
                 ESP_LOGI(TAG, "Data size: %d\r\n", rsp.data.blueCherry.messages[msgIdx].dataSize);
 
+                /*
                 for (uint8_t byteIdx = 0; byteIdx < rsp.data.blueCherry.messages[msgIdx].dataSize;
                      byteIdx++) {
                     ESP_LOGI(TAG, "%c", rsp.data.blueCherry.messages[msgIdx].data[byteIdx]);
                 }
+                */
+                rsp.data.blueCherry.messages[msgIdx]
+                    .data[rsp.data.blueCherry.messages[msgIdx].dataSize] = '\0';
+
+                // Log the message as a string
+                ESP_LOGI(TAG, "%s", rsp.data.blueCherry.messages[msgIdx].data);
             }
         }
     } while (!rsp.data.blueCherry.syncFinished);

--- a/examples/bluecherry/main/bluecherry_example.cpp
+++ b/examples/bluecherry/main/bluecherry_example.cpp
@@ -210,7 +210,10 @@ void syncBlueCherry()
 
         for (uint8_t msgIdx = 0; msgIdx < rsp.data.blueCherry.messageCount; msgIdx++) {
             if (rsp.data.blueCherry.messages[msgIdx].topic == 0) {
-                ESP_LOGI(TAG, "Downloading new firmware version");
+                ESP_LOGI(
+                    TAG,
+                    "Downloading new firmware version: %d%% complete",
+                    modem.blueCherryGetOtaProgressPercentage());
                 break;
             } else {
                 ESP_LOGI(

--- a/examples/bluecherry/main/bluecherry_example.cpp
+++ b/examples/bluecherry/main/bluecherry_example.cpp
@@ -48,8 +48,8 @@
  */
 
 #include <WalterModem.h>
-#include <Bluecherry_ZTP/BlueCherryZTP.h>
-#include <Bluecherry_ZTP/BlueCherryZTP_CBOR.h>
+#include <BlueCherryZTP.h>
+#include <BlueCherryZTP_CBOR.h>
 #include <driver/uart.h>
 #include <esp_log.h>
 #include <esp_mac.h>

--- a/examples/bluecherry/main/idf_component.yml
+++ b/examples/bluecherry/main/idf_component.yml
@@ -1,4 +1,4 @@
 dependencies:
   idf: ">=5.0.0"
   dptechnics/walter-modem:
-    version: ">=1.2.0"
+    version: ">=1.2.1"

--- a/examples/coap/main/Kconfig.projbuild
+++ b/examples/coap/main/Kconfig.projbuild
@@ -15,6 +15,7 @@ menu "coap example"
         config MODEM_COAP_PROFILE
             int "the COAP profile id"
             default 0
+            range 0 WALTER_MODEM_MAX_HTTP_PROFILES
     endif
     
 endmenu

--- a/examples/coap/main/coap_example.cpp
+++ b/examples/coap/main/coap_example.cpp
@@ -255,9 +255,9 @@ extern "C" void app_main(void)
                 ESP_LOGI(TAG, "Method or response code: %d\r\n", rsp.data.coapResponse.methodRsp);
                 ESP_LOGI(TAG, "Data (%d bytes):\r\n", rsp.data.coapResponse.length);
 
-                for (size_t i = 0; i < rsp.data.coapResponse.length; i++) {
-                    ESP_LOGI(TAG, "[%02x  %c] ", incomingBuf[i], incomingBuf[i]);
-                }
+                incomingBuf[rsp.data.coapResponse.length] = '\0'; // Null-terminate the buffer
+                ESP_LOGI(TAG, "Response: %s", incomingBuf);
+                
                 ESP_LOGI(TAG, "\r\n");
             }
         }

--- a/examples/coap/main/coap_example.cpp
+++ b/examples/coap/main/coap_example.cpp
@@ -256,7 +256,7 @@ extern "C" void app_main(void)
                 ESP_LOGI(TAG, "Data (%d bytes):\r\n", rsp.data.coapResponse.length);
 
                 incomingBuf[rsp.data.coapResponse.length] = '\0'; // Null-terminate the buffer
-                ESP_LOGI(TAG, "Response: %s", incomingBuf);
+                ESP_LOGI(TAG, "Response: '%s'", incomingBuf);
                 
                 ESP_LOGI(TAG, "\r\n");
             }

--- a/examples/coap/main/idf_component.yml
+++ b/examples/coap/main/idf_component.yml
@@ -1,4 +1,4 @@
 dependencies:
   idf: ">=5.0.0"
   dptechnics/walter-modem:
-    version: ">=1.2.0"
+    version: ">=1.2.1"

--- a/examples/http/main/http_example.cpp
+++ b/examples/http/main/http_example.cpp
@@ -99,7 +99,7 @@ uint8_t dataBuf[8] = {0};
 /**
  * @brief Buffer for incoming HTTP response
  */
-uint8_t incomingBuf[256] = {0};
+uint8_t incomingBuf[2500] = {0};
 
 /**
  * @brief The counter used in the ping packets.
@@ -221,7 +221,7 @@ extern "C" void app_main(void)
 
         if (!httpReceiveAttemptsLeft) {
             if (modem.httpQuery(
-                    HTTP_PROFILE, "/", WALTER_MODEM_HTTP_QUERY_CMD_GET, ctbuf, sizeof(ctbuf))) {
+                    MODEM_HTTP_PROFILE, "/", WALTER_MODEM_HTTP_QUERY_CMD_GET, ctbuf, sizeof(ctbuf))) {
                 ESP_LOGI(TAG, "query performed\r\n");
                 httpReceiveAttemptsLeft = MAX_RECEIVE_COUNT;
             } else {
@@ -229,7 +229,7 @@ extern "C" void app_main(void)
                 vTaskDelay(pdMS_TO_TICKS(SEND_DELAY_MS));
             }
         } else {
-            while (modem.httpDidRing(HTTP_PROFILE, incomingBuf, sizeof(incomingBuf), &rsp)) {
+            while (modem.httpDidRing(MODEM_HTTP_PROFILE, incomingBuf, sizeof(incomingBuf), &rsp)) {
                 httpReceiveAttemptsLeft = 0;
 
                 ESP_LOGI(TAG, "status code: %d\r\n", rsp.data.httpResponse.httpStatus);

--- a/examples/http/main/idf_component.yml
+++ b/examples/http/main/idf_component.yml
@@ -15,4 +15,4 @@ dependencies:
   #   # All dependencies of `main` are public by default.
   #   public: true
   dptechnics/walter-modem:
-    version: ">=1.2.0"
+    version: ">=1.2.1"

--- a/examples/mqtt/main/idf_component.yml
+++ b/examples/mqtt/main/idf_component.yml
@@ -1,4 +1,4 @@
 dependencies:
   idf: ">=5.0.0"
   dptechnics/walter-modem:
-    version: ">=1.2.0"
+    version: ">=1.2.1"

--- a/examples/mqtt/main/mqtt_example.cpp
+++ b/examples/mqtt/main/mqtt_example.cpp
@@ -187,7 +187,7 @@ extern "C" void app_main(void)
 
     /* other public mqtt broker with web client: mqtthq.comm */
     /* Configure the mqtt client */
-    if (modem.mqttConfig("walter-mqtt-test-topic")) {
+    if (modem.mqttConfig("walter-mqtt-test-topic","","",0)) {
         ESP_LOGI(TAG, "MQTT configuration succeeded");
     } else {
         ESP_LOGE(TAG, "MQTT configuration failed");

--- a/examples/udp_socket/main/idf_component.yml
+++ b/examples/udp_socket/main/idf_component.yml
@@ -1,4 +1,4 @@
 dependencies:
   idf: ">=5.0.0"
   dptechnics/walter-modem:
-    version: ">=1.2.0"
+    version: ">=1.2.1"

--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -944,8 +944,8 @@ size_t WalterModem::_getCurrentPayloadSize()
 
     // If CRLF is found, return the size of the data after it
     if (crlf_pos != NULL) {
-        size_t payload_size =
-            _parserData.buf->size - (crlf_pos - (char *)_parserData.buf->data) - 2;
+        size_t payload_size = _parserData.buf->size -
+            (crlf_pos - reinterpret_cast<char *>(_parserData.buf->data)) - 2;
         return payload_size;
     }
 

--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -1021,7 +1021,6 @@ bool WalterModem::_checkPayloadComplete()
         &_parserData.buf->data[_receiveExpected], _parserData.buf->size, "\r\nOK\r\n", 6);
 
     if (resultPos && _parserData.buf->size >= _receiveExpected) {
-        ESP_LOGD("WalterParser", "End ok marker found");
         _parserData.buf->size -= 6;
         _queueRxBuffer();
         _resetParseRxFlags();
@@ -1038,7 +1037,6 @@ bool WalterModem::_checkPayloadComplete()
         9);
 
     if (resultPos && _parserData.buf->size >= _receiveExpected) {
-        ESP_LOGD("WalterParser", "End error marker found");
         _parserData.buf->size -= 9;
         _resetParseRxFlags();
         _queueRxBuffer();

--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -2158,11 +2158,11 @@ void WalterModem::_processQueueRsp(WalterModemCmd *cmd, WalterModemBuffer *buff)
          * If data and dataSize are null, we cannot store the result. We can only hope the user is
          * using a callback which has access to the raw buffer.
          */
-        if (cmd->data && cmd->dataSize >= buff->size-2) {
+        if (cmd->data && cmd->dataSize >= buff->size - 2) {
             memcpy(cmd->data, buff->data + 3, buff->size - 3);
             cmd->data[buff->size - 2] = '\0';
         } else {
-            ESP_LOGW("WalterModem","Unable to store HTTP payload (buffer to small)");
+            ESP_LOGW("WalterModem", "Unable to store HTTP payload (buffer to small)");
             result = WALTER_MODEM_STATE_NO_MEMORY;
         }
     } else if (_buffStartsWith(buff, "+SQNHTTPRING: ")) {
@@ -2274,11 +2274,10 @@ void WalterModem::_processQueueRsp(WalterModemCmd *cmd, WalterModemBuffer *buff)
 #if CONFIG_WALTER_MODEM_ENABLE_COAP
     if (_buffStartsWith(buff, "+SQNCOAPRCV: ")) {
         const char *rspStr = _buffStr(buff);
-        char *payload = strchr(rspStr, '\r');
-        if (payload != 0) {
-            payload++;
+        char *payload = strstr(rspStr, "\r\n");
+        if(payload) {
+            payload += 2;
         }
-
         char *commaPos = strchr(rspStr, ',');
         char *start = (char *)rspStr + _strLitLen("+SQNCOAPRCV: ");
         uint8_t profileId = 0;
@@ -2368,6 +2367,7 @@ void WalterModem::_processQueueRsp(WalterModemCmd *cmd, WalterModemBuffer *buff)
              * is using a callback which has access to the raw buffer.
              */
             if (cmd->data) {
+                ESP_LOGD("WalterModem","copied data");
                 memcpy(cmd->data, payload, cmd->rsp->data.coapResponse.length);
             }
         }
@@ -2441,10 +2441,10 @@ void WalterModem::_processQueueRsp(WalterModemCmd *cmd, WalterModemBuffer *buff)
                         lengthStr);
                     const char *_cmdArr[WALTER_MODEM_COMMAND_MAX_ELEMS + 1] =
                         arr((const char *)stringsBuffer->data);
-
+                    _receiving = true;
                     _addQueueCmd(
                         _cmdArr,
-                        "+SQNCOAPRCV: ",
+                        "OK",
                         NULL,
                         coapReceivedFromBlueCherry,
                         &blueCherry,

--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -2621,7 +2621,7 @@ void WalterModem::_processQueueRsp(WalterModemCmd *cmd, WalterModemBuffer *buff)
          * is using a callback which has access to the raw buffer.
          */
         if (cmd->data) {
-            memcpy(cmd->data, data, sock->dataReceived);
+            memcpy(cmd->data, data + 1, sock->dataReceived);
         }
     }
 #endif

--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -1037,7 +1037,7 @@ void WalterModem::_parseRxData(char *rxData, size_t len)
     bool hasLF = memchr(rxData, '\n', len) != nullptr;
     bool hasTripleChevron = memmem(rxData, len, "<<<", 3) != nullptr; //HTTP data sequence
 
-    if (hasCR && hasLF || hasTripleChevron)
+    if ((hasCR && hasLF) || hasTripleChevron)
     {
         //OUR PAYLOAD is complete
         _parserData.rawChunkSize = _extractPayloadSize();

--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -1036,7 +1036,7 @@ void WalterModem::_parseRxData(char *rxData, size_t len)
     bool hasLF = memchr(rxData, '\n', len) != nullptr;
     bool hasTripleChevron = memmem(rxData, len, "<<<", 3) != nullptr; //HTTP data sequence
 
-    if (hasCR && hasLF)
+    if (hasCR && hasLF || hasTripleChevron)
     {
         //OUR PAYLOAD is complete
         _parserData.rawChunkSize = _extractPayloadSize();
@@ -1064,14 +1064,14 @@ void WalterModem::_parseRxData(char *rxData, size_t len)
             char *crlf_pos = (char *)memmem(rxData, len, "\r\n", 2);
             if (crlf_pos != nullptr) {
                 size_t bytesToAdd = crlf_pos - rxData + 2;
-                addATBytesToBuffer(rxData, bytesToAdd);
+                _addATBytesToBuffer(rxData, bytesToAdd);
                 _queueRxBuffer();
                 size_t remainingBytes = len - bytesToAdd;
-                addATBytesToBuffer(rxData + bytesToAdd, remainingBytes);
+                _addATBytesToBuffer(rxData + bytesToAdd, remainingBytes);
             }
         }
     } else {
-        _addATBytesToBuffer()
+        _addATBytesToBuffer(rxData,len);
     }
 }
 

--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -2276,7 +2276,7 @@ void WalterModem::_processQueueRsp(WalterModemCmd *cmd, WalterModemBuffer *buff)
         const char *rspStr = _buffStr(buff);
         char *payload = strstr(rspStr, "\r\n");
         if(payload) {
-            payload += 2;
+            payload += 1;
         }
         char *commaPos = strchr(rspStr, ',');
         char *start = (char *)rspStr + _strLitLen("+SQNCOAPRCV: ");

--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -1046,7 +1046,7 @@ void WalterModem::_parseRxData(char *rxData, size_t len)
             ESP_LOGD("WalterParser", "Receiving payload data");
             // TODO wait until we have the ending \r\nOK\r\n or \r\nERROR\r\n
             char *okPos = (char*)memmem(dataStart, dataLen, "\r\nOK\r\n", 6);
-            char *errorPos = (char*)memmem(dataStart, dataLen, "\r\nERROR\r\n", 8);
+            char *errorPos = (char*)memmem(dataStart, dataLen, "\r\nERROR\r\n", 9);
 
             char *endMarker = (okPos && (!errorPos || okPos < errorPos)) ? okPos : errorPos;
             if (endMarker) {
@@ -2276,7 +2276,7 @@ void WalterModem::_processQueueRsp(WalterModemCmd *cmd, WalterModemBuffer *buff)
         const char *rspStr = _buffStr(buff);
         char *payload = strstr(rspStr, "\r\n");
         if(payload) {
-            payload += 1;
+            payload += 2;
         }
         char *commaPos = strchr(rspStr, ',');
         char *start = (char *)rspStr + _strLitLen("+SQNCOAPRCV: ");
@@ -2358,6 +2358,7 @@ void WalterModem::_processQueueRsp(WalterModemCmd *cmd, WalterModemBuffer *buff)
 
             if (length > cmd->dataSize) {
                 cmd->rsp->data.coapResponse.length = cmd->dataSize;
+                ESP_LOGD("WalterModem", "datasize");
             } else {
                 cmd->rsp->data.coapResponse.length = length;
             }

--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -944,7 +944,8 @@ size_t WalterModem::_getCurrentPayloadSize()
 
     // If CRLF is found, return the size of the data after it
     if (crlf_pos != NULL) {
-        size_t payload_size = _parserData.buf->size - (crlf_pos - _parserData.buf->data) - 2;
+        size_t payload_size =
+            _parserData.buf->size - (crlf_pos - (char *)_parserData.buf->data) - 2;
         return payload_size;
     }
 

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -3277,6 +3277,13 @@ private:
     static void _queueRxBuffer();
 
     /**
+     * @brief returns the CRLF position
+     *
+     * @param data The incoming data buffer.
+     * @param len The number of bytes in the rxData buffer.
+     */
+    static size_t _getCRLFPosition(const char *rxData, size_t len);
+    /**
      * @brief Parse incoming modem data.
      *
      * @param rxData The incoming data buffer.

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -2831,6 +2831,11 @@ private:
     static inline bool _initialized = false;
 
     /**
+     * @brief boolean for when we are doing a hardware reset.
+     */
+    static inline bool _hardwareReset = false;
+
+    /**
      * @brief We remember the configured watchdog timeout.
      */
     static inline uint8_t _watchdogTimeout = false;

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -2715,7 +2715,7 @@ typedef struct {
     /**
      * @brief In raw data chunk parser state, we remember nr expected bytes
      */
-    uint16_t rawChunkSize = 0;
+    size_t rawChunkSize = 0;
 } WalterModemATParserData;
 
 /**
@@ -3211,12 +3211,18 @@ private:
 
 #pragma region CMD_PROCESSING
     /**
-     * @brief Test if the new buffer line starts a raw data chunk
+     * @brief this function extracts the expected payloadSize.
      *
-     * @return Size of the expected raw data chunk
+     * @return Size of the expected payload
      */
-    static uint16_t _extractRawBufferChunkSize();
+    static size_t _extractPayloadSize();
 
+    /**
+     * @brief this function extracts the current payloadSize in the _parserData buffer.
+     * 
+     * @return currentSize fo the payload already received.
+     */
+    static size_t _getCurrentPayloadSize();
     /**
      * @brief Get a free buffer from the buffer pool.
      *
@@ -3236,6 +3242,19 @@ private:
      * @return None.
      */
     static void _addATByteToBuffer(char data, bool raw);
+
+    /**
+     * @brief Handle an AT data byte.
+     *
+     * This function is used by the AT data parser to add a databyte to the buffer currently in
+     * use or to reserve a new buffer to add a byte to.
+     *
+     * @param data The data byte to handle.
+     * @param lenght The lenght of the data to add.
+     *
+     * @return None.
+     */
+    static void _addATBytesToBuffer(const char *data, size_t length);
 
     /**
      * @brief Copy the currently received data buffer into the task queue.

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -2840,7 +2840,7 @@ private:
      */
     static inline bool _receiving = false;
 
-    static inline bool foundCRLF = false;
+    static inline bool _foundCRLF = false;
 
     static inline size_t currentCRLF = 0;
 
@@ -3298,6 +3298,13 @@ private:
      */
     static void _parseRxData(char *rxData, size_t len);
 
+    /**
+     * @brief This function resets the payload receiving flags.
+     */
+    static void _resetParseRxFlags();
+    /**
+     * @brief This function checks if a full payload was received, if so it queues it and sends the appropriate return RX command.
+     */
     static bool _checkPayloadComplete();
 #ifdef ARDUINO
         /**
@@ -4440,37 +4447,53 @@ public:
      */
     static bool blueCherryClose(
         WalterModemRsp *rsp = NULL, walterModemCb cb = NULL, void *args = NULL);
+
+    /**
+     * @brief This function returns the current OTA progress.
+     */
+    static size_t blueCherryGetOtaProgressPercentage();
+
+    /**
+     * @brief This function returns the current OTA progress in bytes.
+     */
+    static size_t blueCherryGetOtaProgressBytes();
+
+    /**
+     * @brief This function returns the total OTA size.
+     */
+    static size_t blueCherryGetOtaSize();
 #endif
 #pragma endregion
 
 #pragma region COAP
 #if CONFIG_WALTER_MODEM_ENABLE_COAP
-    /**
-     * @brief Create a CoAP context.
-     *
-     * This function will create a CoAP context if it was not open yet. This needs to be done
-     * before you can set headers or options or send or receive data.
-     *
-     * @param profileId CoAP profile id (0 is used by BlueCherry)
-     * @param serverName The server name to connect to.
-     * @param port The port of the server to connect to.
-     * @param tlsProfileId If not 0, DTLS is used with the given profile (1-6).
-     * @param localPort The local port to use (default 0=random).
-     * @param rsp Optional modem response structure to save the result in.
-     * @param cb Optional callback function, if set this function will not block.
-     * @param args Optional argument to pass to the callback.
-     *
-     * @return True on success, false otherwise.
-     */
-    static bool coapCreateContext(
-        uint8_t profileId,
-        const char *serverName,
-        int port,
-        uint8_t tlsProfileId = 0,
-        int localPort = -1,
-        WalterModemRsp *rsp = NULL,
-        walterModemCb cb = NULL,
-        void *args = NULL);
+        /**
+         * @brief Create a CoAP context.
+         *
+         * This function will create a CoAP context if it was not open yet. This needs to be done
+         * before you can set headers or options or send or receive data.
+         *
+         * @param profileId CoAP profile id (0 is used by BlueCherry)
+         * @param serverName The server name to connect to.
+         * @param port The port of the server to connect to.
+         * @param tlsProfileId If not 0, DTLS is used with the given profile (1-6).
+         * @param localPort The local port to use (default 0=random).
+         * @param rsp Optional modem response structure to save the result in.
+         * @param cb Optional callback function, if set this function will not block.
+         * @param args Optional argument to pass to the callback.
+         *
+         * @return True on success, false otherwise.
+         */
+        static bool
+        coapCreateContext(
+            uint8_t profileId,
+            const char *serverName,
+            int port,
+            uint8_t tlsProfileId = 0,
+            int localPort = -1,
+            WalterModemRsp *rsp = NULL,
+            walterModemCb cb = NULL,
+            void *args = NULL);
 
     /**
      * @brief Close a CoAP context.

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -2840,6 +2840,11 @@ private:
      */
     static inline bool _receiving = false;
 
+    static inline bool foundCRLF = false;
+
+    static inline size_t currentCRLF = 0;
+
+    static inline size_t _receiveExpected = true;
     /**
      * @brief We remember the configured watchdog timeout.
      */
@@ -3292,30 +3297,32 @@ private:
      * @return None.
      */
     static void _parseRxData(char *rxData, size_t len);
+
+    static bool _checkPayloadComplete();
 #ifdef ARDUINO
-    /**
-     * @brief Handle and parse modem RX data.
-     *
-     * This function is called when the modem placed data in the UART RX buffer. The context is
-     * a vTask in the ESP32 Arduino core framework and not an ISR, therefore this function also
-     * immediately parses the incoming data into a free pool buffer.
-     *
-     * @return None.
-     */
-    static void _handleRxData(void);
+        /**
+         * @brief Handle and parse modem RX data.
+         *
+         * This function is called when the modem placed data in the UART RX buffer. The context is
+         * a vTask in the ESP32 Arduino core framework and not an ISR, therefore this function also
+         * immediately parses the incoming data into a free pool buffer.
+         *
+         * @return None.
+         */
+        static void _handleRxData(void);
 #else
-    /**
-     * @brief Handle and parse modem RX data.
-     *
-     * This function is called when the modem placed data in the UART RX buffer. The context is
-     * a vTask in the ESP32 Arduino core framework and not an ISR, therefore this function also
-     * immediately parses the incoming data into a free pool buffer.
-     *
-     * @param params Incoming params for this FreeRTOS task handler.
-     *
-     * @return None.
-     */
-    static void _handleRxData(void *params);
+        /**
+         * @brief Handle and parse modem RX data.
+         *
+         * This function is called when the modem placed data in the UART RX buffer. The context is
+         * a vTask in the ESP32 Arduino core framework and not an ISR, therefore this function also
+         * immediately parses the incoming data into a free pool buffer.
+         *
+         * @param params Incoming params for this FreeRTOS task handler.
+         *
+         * @return None.
+         */
+        static void _handleRxData(void *params);
 #endif
     /**
      * @brief This is the entrypoint of the queue processing task.

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -2836,6 +2836,11 @@ private:
     static inline bool _hardwareReset = false;
 
     /**
+     * @brief boolean for when we are doing a hardware reset.
+     */
+    static inline bool _receiving = false;
+
+    /**
      * @brief We remember the configured watchdog timeout.
      */
     static inline uint8_t _watchdogTimeout = false;

--- a/src/proto/WalterBlueCherry.cpp
+++ b/src/proto/WalterBlueCherry.cpp
@@ -319,6 +319,25 @@ bool WalterModem::blueCherryClose(WalterModemRsp *rsp, walterModemCb cb, void *a
     _returnAfterReply();
 }
 
+
+size_t WalterModem::blueCherryGetOtaProgressPercentage()
+{
+    if (blueCherry.otaSize == 0) {
+        return 0; /* NO deviding by ZERO*/
+    }
+    return (blueCherry.otaProgress * 100) / blueCherry.otaSize;
+}
+
+
+size_t WalterModem::blueCherryGetOtaProgressBytes() 
+{
+    return blueCherry.otaProgress;
+}
+size_t WalterModem::blueCherryGetOtaSize()
+{
+    return blueCherry.otaSize;
+}
+
     #pragma endregion
 
 #endif

--- a/src/proto/WalterCoAP.cpp
+++ b/src/proto/WalterCoAP.cpp
@@ -98,10 +98,11 @@ bool WalterModem::coapDidRing(
         profileId,
         _coapContextSet[profileId].rings[ringIdx].messageId,
         _coapContextSet[profileId].rings[ringIdx].length);
-
+        
+    _receiving = true;
     _runCmd(
         arr((const char *)stringsBuffer->data),
-        "+SQNCOAPRCV: ",
+        "OK",
         rsp,
         cb,
         args,

--- a/src/proto/WalterCoAP.cpp
+++ b/src/proto/WalterCoAP.cpp
@@ -90,7 +90,9 @@ bool WalterModem::coapDidRing(
     if (ringIdx == WALTER_MODEM_COAP_MAX_PENDING_RINGS) {
         _returnState(WALTER_MODEM_STATE_NO_DATA);
     }
-
+    if(_coapContextSet[profileId].rings[ringIdx].length == 0) {
+        _returnState(WALTER_MODEM_STATE_OK);
+    }
     WalterModemBuffer *stringsBuffer = _getFreeBuffer();
     stringsBuffer->size += sprintf(
         (char *)stringsBuffer->data,
@@ -100,6 +102,7 @@ bool WalterModem::coapDidRing(
         _coapContextSet[profileId].rings[ringIdx].length);
         
     _receiving = true;
+    _receiveExpected = _coapContextSet[profileId].rings[ringIdx].length;
     _runCmd(
         arr((const char *)stringsBuffer->data),
         "OK",

--- a/src/proto/WalterHTTP.cpp
+++ b/src/proto/WalterHTTP.cpp
@@ -323,7 +323,7 @@ bool WalterModem::httpDidRing(
         _httpContextSet[_httpCurrentProfile].state = WALTER_MODEM_HTTP_CONTEXT_STATE_IDLE;
         _httpCurrentProfile = 0xff;
     };
-
+    _receiving = true;
     _runCmd(
         arr("AT+SQNHTTPRCV=", _atNum(profileId)),
         "<<<",

--- a/src/proto/WalterHTTP.cpp
+++ b/src/proto/WalterHTTP.cpp
@@ -309,13 +309,8 @@ bool WalterModem::httpDidRing(
         _returnState(WALTER_MODEM_STATE_ERROR);
     }
 
-    if (_httpContextSet[profileId].contentLength == 0) {
-        _httpContextSet[profileId].state = WALTER_MODEM_HTTP_CONTEXT_STATE_IDLE;
-        rsp->type = WALTER_MODEM_RSP_DATA_TYPE_HTTP_RESPONSE;
-        rsp->data.httpResponse.httpStatus = _httpContextSet[profileId].httpStatus;
-        rsp->data.httpResponse.contentLength = 0;
-        _returnState(WALTER_MODEM_STATE_NO_DATA);
-    }
+    /* in the case of chunked data contentLenght can be zero! */
+
 
     _httpCurrentProfile = profileId;
 

--- a/src/proto/WalterHTTP.cpp
+++ b/src/proto/WalterHTTP.cpp
@@ -326,7 +326,7 @@ bool WalterModem::httpDidRing(
     _receiving = true;
     _runCmd(
         arr("AT+SQNHTTPRCV=", _atNum(profileId)),
-        "<<<",
+        "OK",
         rsp,
         cb,
         args,

--- a/src/proto/WalterMQTT.cpp
+++ b/src/proto/WalterMQTT.cpp
@@ -230,6 +230,7 @@ bool WalterModem::mqttDidRing(
     if (targetBufSize < _mqttRings[idx].length) {
         _returnState(WALTER_MODEM_STATE_NO_MEMORY);
     }
+    _receiving = true;
 
     if (_mqttRings[idx].qos == 0) {
         /* no msg id means qos 0 message */

--- a/src/proto/WalterSocket.cpp
+++ b/src/proto/WalterSocket.cpp
@@ -414,12 +414,13 @@ bool WalterModem::socketReceive(
         _returnState(WALTER_MODEM_STATE_NO_MEMORY);
     }
     _receiving = true;
+    _receiveExpected = sock->dataReceived;
     _runCmd(
         arr("AT+SQNSRECV=", _digitStr(sock->id), ",", _atNum(targetBufSize)),
         "OK",
         rsp,
-        NULL,
-        NULL,
+        cb,
+        args,
         NULL,
         NULL,
         WALTER_MODEM_CMD_TYPE_TX_WAIT,

--- a/src/proto/WalterSocket.cpp
+++ b/src/proto/WalterSocket.cpp
@@ -413,7 +413,7 @@ bool WalterModem::socketReceive(
     if (targetBufSize > 1500) {
         _returnState(WALTER_MODEM_STATE_NO_MEMORY);
     }
-
+    _receiving = true;
     _runCmd(
         arr("AT+SQNSRECV=", _digitStr(sock->id), ",", _atNum(targetBufSize)),
         "OK",


### PR DESCRIPTION
closes #60

# UART parser:

currently the UART parser implementation does not conform to how messages should be expected from the sequans modem, IE end with an `\r\nOK\r\n`.

## REWRITE:
with these problems in mind a rewrite of the _parseRxData function has been done.

### goals:
- make the the code more readable.
- use optemized c-functions for parsing.
- remove the payload hacks.
- document the rewrite.
- performance improvement.
- add support for waiting for OK when receiving.
