### PR TITLE
Feat(bluecherry psm example): BlueCherry example update with deepsleep and PSM

### DIFF
--- a/examples/bluecherry/main/Kconfig.projbuild
+++ b/examples/bluecherry/main/Kconfig.projbuild
@@ -16,5 +16,16 @@ menu "Walter BlueCherry example"
             help
                 Specify what TLS profile ID the modem will use to configure TLS communication with BlueCherry.
                 It is recommended to not re-use this profile for other TLS-enabled communication.
+        config PSM_ACTIVE
+            string "PSM active time"
+            default "00000001"
+            help
+                Specify the PSM active time.
+        
+        config PSM_TAU
+            string "PSM TAU time"
+            default "00000110"
+            help
+                Specify the PSM tau time.
     endif
 endmenu

--- a/examples/bluecherry/main/bluecherry_example.cpp
+++ b/examples/bluecherry/main/bluecherry_example.cpp
@@ -47,12 +47,13 @@
  * It also supports OTA updates which are scheduled through the BlueCherry web interface.
  */
 
-#include <WalterModem.h>
 #include <BlueCherryZTP.h>
 #include <BlueCherryZTP_CBOR.h>
+#include <WalterModem.h>
 #include <driver/uart.h>
 #include <esp_log.h>
 #include <esp_mac.h>
+#include <esp_sleep.h>
 
 WalterModem modem;
 
@@ -70,6 +71,15 @@ CONFIG(BC_DEVICE_TYPE, const char *, "walter01")
  * @brief Define modem TLS profile used for BlueCherry cloud platform
  */
 CONFIG_UINT8(BC_TLS_PROFILE, 1)
+
+/**
+ * @brief The binary configuration settings for PSM.
+ * These can be calculated using e.g.
+ * https://www.soracom.io/psm-calculation-tool/
+ */
+CONFIG(PSM_ACTIVE, const char *, "00000001");
+
+CONFIG(PSM_TAU, const char *, "00000110");
 
 /**
  * @brief ESP-IDF log prefix.
@@ -205,6 +215,7 @@ void syncBlueCherry()
                 rsp.data.blueCherry.state);
             modem.softReset();
             lteConnect();
+            modem.blueCherryInit(BC_TLS_PROFILE, otaBuffer);
             return;
         }
 
@@ -315,7 +326,7 @@ void configureBluecherry()
 
 extern "C" void app_main(void)
 {
-    ESP_LOGI(TAG, "Walter modem bluecherry example v1.0.0");
+    ESP_LOGI(TAG, "Walter BlueCherry ZTP + OTA + PSM example. v1.1.0");
 
     /* Get the MAC address for board validation */
     esp_read_mac(dataBuf, ESP_MAC_WIFI_STA);
@@ -334,18 +345,33 @@ extern "C" void app_main(void)
         ESP_LOGI(TAG, "Modem initialization OK");
     } else {
         ESP_LOGE(TAG, "Modem initialization ERROR");
-        return;
+        vTaskDelay(pdMS_TO_TICKS(10000));
+        esp_restart();
     }
 
-    /* Connect the modem to the lte network */
-    if (!lteConnect()) {
-        ESP_LOGE(TAG, "Could Not Connect to LTE");
-        return;
+    modem.configPSM(WALTER_MODEM_PSM_ENABLE,PSM_TAU,PSM_ACTIVE);
+
+    /* Connect to cellular network */
+    if (!lteConnected() && !lteConnect()) {
+        ESP_LOGE(TAG,"Unable to connect to cellular network, restarting Walter "
+                    "in 10 seconds");
+        vTaskDelay(pdMS_TO_TICKS(10000));
+        esp_restart();
     }
-    
-    configureBluecherry();
+
+    if (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_UNDEFINED) {
+        configureBluecherry();
+    }
 
     for (;;) {
+        /* Connect to cellular network */
+        if (!lteConnected() && !lteConnect()) {
+            ESP_LOGE(TAG,"Unable to connect to cellular network, restarting Walter "
+                        "in 10 seconds");
+            vTaskDelay(pdMS_TO_TICKS(10000));
+            esp_restart();
+        }
+
         WalterModemRsp rsp = {};
         if (modem.getCellInformation(WALTER_MODEM_SQNMONI_REPORTS_SERVING_CELL, &rsp)) {
             char msg[18];
@@ -353,9 +379,13 @@ extern "C" void app_main(void)
             modem.blueCherryPublish(0x84, sizeof(msg) - 1, (uint8_t *)msg);
         }
 
-        // Poll BlueCherry platform if an incoming message or firmware update is available
+        /* Poll BlueCherry platform if an incoming message or firmware update is available */
         syncBlueCherry();
 
-        vTaskDelay(pdMS_TO_TICKS(60000));
+        /* Wait for PSM to become active */
+        vTaskDelay(pdMS_TO_TICKS(20000));
+
+        /* Go sleep for a minute */
+        modem.sleep(60);
     }
 }

--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -3171,8 +3171,6 @@ bool WalterModem::_processMotaChunkEvent(uint8_t *data, uint16_t len)
 
 bool WalterModem::_processMotaFinishEvent(void)
 {
-    char *atCmd[WALTER_MODEM_COMMAND_MAX_ELEMS + 1] = {NULL};
-
     if (!_blueCherry.otaSize || _blueCherry.otaProgress != _blueCherry.otaSize || !_mota_file_ptr) {
         ESP_LOGD("WalterModem", "MOTA error: incomplete or missing dup file");
         return true;
@@ -3658,7 +3656,7 @@ bool WalterModem::softReset(WalterModemRsp *rsp, walterModemCb cb, void *args)
 #endif
 
 #if CONFIG_WALTER_MODEM_ENABLE_BLUE_CHERRY
-    _blueCherry.bcSocketId = NULL;
+    _blueCherry.bcSocketId = 0;
 #endif
     _operator = {};
 
@@ -3722,7 +3720,7 @@ bool WalterModem::reset(WalterModemRsp *rsp, walterModemCb cb, void *args)
 #endif
 
 #if CONFIG_WALTER_MODEM_ENABLE_BLUE_CHERRY
-    _blueCherry.bcSocketId = NULL;
+    _blueCherry.bcSocketId = 0;
 #endif
     _operator = {};
 

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -4757,17 +4757,6 @@ public:
 
 #pragma region SOCKETS
 #if CONFIG_WALTER_MODEM_ENABLE_SOCKETS
-    
-    /**
-     * @brief Reserve a socket and return it's identifier number.
-     * 
-     * This function will reserve a socket identification number, the socket will not yet be
-     * configured in the modem and expects to be used later for configuration.
-     *
-     * @return Socket ID on success (1-6), NULL if no socket was available. 
-     */
-    static int reserveSocketId();
-
     /**
      * @brief Configure a new socket in a certain PDP context.
      *

--- a/src/proto/WalterSocket.cpp
+++ b/src/proto/WalterSocket.cpp
@@ -126,15 +126,6 @@ void WalterModem::_dispatchEvent(
     #pragma endregion
 
     #pragma region PUBLIC_METHODS
-int WalterModem::reserveSocketId() {
-    WalterModemSocket *sock = _socketReserve();
-    if (sock == NULL) {
-        return NULL;
-    }
-
-    return sock->id;
-}
-
 bool WalterModem::socketConfig(
     WalterModemRsp *rsp,
     walterModemCb cb,


### PR DESCRIPTION
updated the BlueCherry example to follow the changes from `ARDUINO `  and added PSM variables to the `Kconfig.projbuild`