### PR TITLE
release(1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,10 +232,18 @@ This is the Changelog for WalterModem
 
 > This release contains several breaking changes to earlier versions. Please read the description and review the updated examples carefully before updating.
 
-- release(1.5.0) [#152](https://github.com/QuickSpot/walter-esp-idf/pull/152)
+### Features
+
+- feat(WalterModem): Event handling refactor and parser fixes [BREAKING] ([#136](https://github.com/QuickSpot/walter-arduino/pull/136))
+- feat(WalterModem): Modem temperature and voltage monitoring support ([#137](https://github.com/QuickSpot/walter-arduino/pull/137))
 
 ### Bug Fixes
 
 - fix(WalterSocket): panic after close before data received racecondition ([#110](https://github.com/QuickSpot/walter-arduino/pull/110))
-- fix(WalterModem): Retrieving ICCID and eUICCID using getSIMCardID() ([#110](https://github.com/QuickSpot/walter-arduino/pull/126))
+- fix(WalterModem): Retrieving ICCID and eUICCID using getSIMCardID() ([#126](https://github.com/QuickSpot/walter-arduino/pull/126))
+- fix(http): httpStatus should be uint16_t ([#128](https://github.com/QuickSpot/walter-esp-idf/pull/128))
+- Add extra_header_line parameter to HTTP function ([#120](https://github.com/QuickSpot/walter-arduino/pull/120))
 
+### Examples
+
+- [[walter-esp-idf](https://github.com/QuickSpot/walter-esp-idf)] example(WalterModem): Updated examples for latest changes [BREAKING] ([#153](https://github.com/QuickSpot/walter-esp-idf/pull/153))

--- a/examples/coap/main/coap.cpp
+++ b/examples/coap/main/coap.cpp
@@ -198,47 +198,50 @@ bool lteConnect()
 /**
  * @brief The network registration event handler.
  *
- * You can use this handler to get notified of network registration state changes. For this example,
- * we use polling to get the network registration state. You can use this to implement your own
- * reconnection logic.
+ * This function will be called when network registration state changes or when
+ * eDRX parameters are received from the network.
  *
- * @note Make sure to keep this handler as lightweight as possible to avoid blocking the event
- * processing task.
+ * @note Make sure to keep this handler as lightweight as possible to avoid blocking
+ * the event processing task.
  *
- * @param[out] state The network registration state.
+ * @param[out] event The network registration state event.
+ * @param[out] data The registration event data including state and PSM info.
  * @param[out] args User arguments.
  *
  * @return void
  */
-static void myNetworkEventHandler(WalterModemNetworkRegState state, void* args)
+static void myNetworkEventHandler(WMNetworkEventType event, const WMNetworkEventData* data,
+                                  void* args)
 {
-  switch(state) {
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
-    ESP_LOGI(TAG, "Network registration: Registered (home)");
-    break;
+  if(event == WALTER_MODEM_NETWORK_EVENT_REG_STATE_CHANGE) {
+    switch(data->cereg.state) {
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
+      ESP_LOGI(TAG, "Network registration: Registered (home)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
-    ESP_LOGI(TAG, "Network registration: Registered (roaming)");
-    break;
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
+      ESP_LOGI(TAG, "Network registration: Registered (roaming)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Not searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Not searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_DENIED:
-    ESP_LOGI(TAG, "Network registration: Denied");
-    break;
+    case WALTER_MODEM_NETWORK_REG_DENIED:
+      ESP_LOGI(TAG, "Network registration: Denied");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_UNKNOWN:
-    ESP_LOGI(TAG, "Network registration: Unknown");
-    break;
+    case WALTER_MODEM_NETWORK_REG_UNKNOWN:
+      ESP_LOGI(TAG, "Network registration: Unknown");
+      break;
 
-  default:
-    break;
+    default:
+      break;
+    }
   }
 }
 

--- a/examples/coap/main/coap.cpp
+++ b/examples/coap/main/coap.cpp
@@ -305,7 +305,7 @@ extern "C" void app_main(void)
   }
 
   /* Set the network registration event handler (optional) */
-  modem.setRegistrationEventHandler(myNetworkEventHandler, NULL);
+  modem.setNetworkEventHandler(myNetworkEventHandler, NULL);
 
   /* Set the CoAP event handler */
   modem.setCoAPEventHandler(myCoAPEventHandler, NULL);

--- a/examples/http/main/http.cpp
+++ b/examples/http/main/http.cpp
@@ -345,7 +345,7 @@ extern "C" void app_main()
   }
 
   /* Set the network registration event handler (optional) */
-  modem.setRegistrationEventHandler(myNetworkEventHandler, NULL);
+  modem.setNetworkEventHandler(myNetworkEventHandler, NULL);
 
   /* Set the HTTP event handler */
   modem.setHTTPEventHandler(myHTTPEventHandler, NULL);

--- a/examples/http/main/http.cpp
+++ b/examples/http/main/http.cpp
@@ -196,47 +196,50 @@ bool lteConnect()
 /**
  * @brief The network registration event handler.
  *
- * You can use this handler to get notified of network registration state changes. For this example,
- * we use polling to get the network registration state. You can use this to implement your own
- * reconnection logic.
+ * This function will be called when network registration state changes or when
+ * eDRX parameters are received from the network.
  *
- * @note Make sure to keep this handler as lightweight as possible to avoid blocking the event
- * processing task.
+ * @note Make sure to keep this handler as lightweight as possible to avoid blocking
+ * the event processing task.
  *
- * @param[out] state The network registration state.
+ * @param[out] event The network registration state event.
+ * @param[out] data The registration event data including state and PSM info.
  * @param[out] args User arguments.
  *
  * @return void
  */
-static void myNetworkEventHandler(WalterModemNetworkRegState state, void* args)
+static void myNetworkEventHandler(WMNetworkEventType event, const WMNetworkEventData* data,
+                                  void* args)
 {
-  switch(state) {
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
-    ESP_LOGI(TAG, "Network registration: Registered (home)");
-    break;
+  if(event == WALTER_MODEM_NETWORK_EVENT_REG_STATE_CHANGE) {
+    switch(data->cereg.state) {
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
+      ESP_LOGI(TAG, "Network registration: Registered (home)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
-    ESP_LOGI(TAG, "Network registration: Registered (roaming)");
-    break;
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
+      ESP_LOGI(TAG, "Network registration: Registered (roaming)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Not searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Not searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_DENIED:
-    ESP_LOGI(TAG, "Network registration: Denied");
-    break;
+    case WALTER_MODEM_NETWORK_REG_DENIED:
+      ESP_LOGI(TAG, "Network registration: Denied");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_UNKNOWN:
-    ESP_LOGI(TAG, "Network registration: Unknown");
-    break;
+    case WALTER_MODEM_NETWORK_REG_UNKNOWN:
+      ESP_LOGI(TAG, "Network registration: Unknown");
+      break;
 
-  default:
-    break;
+    default:
+      break;
+    }
   }
 }
 

--- a/examples/https/main/https.cpp
+++ b/examples/https/main/https.cpp
@@ -277,47 +277,50 @@ bool setupTLSProfile(void)
 /**
  * @brief The network registration event handler.
  *
- * You can use this handler to get notified of network registration state changes. For this example,
- * we use polling to get the network registration state. You can use this to implement your own
- * reconnection logic.
+ * This function will be called when network registration state changes or when
+ * eDRX parameters are received from the network.
  *
- * @note Make sure to keep this handler as lightweight as possible to avoid blocking the event
- * processing task.
+ * @note Make sure to keep this handler as lightweight as possible to avoid blocking
+ * the event processing task.
  *
- * @param[out] state The network registration state.
+ * @param[out] event The network registration state event.
+ * @param[out] data The registration event data including state and PSM info.
  * @param[out] args User arguments.
  *
  * @return void
  */
-static void myNetworkEventHandler(WalterModemNetworkRegState state, void* args)
+static void myNetworkEventHandler(WMNetworkEventType event, const WMNetworkEventData* data,
+                                  void* args)
 {
-  switch(state) {
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
-    ESP_LOGI(TAG, "Network registration: Registered (home)");
-    break;
+  if(event == WALTER_MODEM_NETWORK_EVENT_REG_STATE_CHANGE) {
+    switch(data->cereg.state) {
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
+      ESP_LOGI(TAG, "Network registration: Registered (home)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
-    ESP_LOGI(TAG, "Network registration: Registered (roaming)");
-    break;
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
+      ESP_LOGI(TAG, "Network registration: Registered (roaming)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Not searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Not searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_DENIED:
-    ESP_LOGI(TAG, "Network registration: Denied");
-    break;
+    case WALTER_MODEM_NETWORK_REG_DENIED:
+      ESP_LOGI(TAG, "Network registration: Denied");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_UNKNOWN:
-    ESP_LOGI(TAG, "Network registration: Unknown");
-    break;
+    case WALTER_MODEM_NETWORK_REG_UNKNOWN:
+      ESP_LOGI(TAG, "Network registration: Unknown");
+      break;
 
-  default:
-    break;
+    default:
+      break;
+    }
   }
 }
 

--- a/examples/https/main/https.cpp
+++ b/examples/https/main/https.cpp
@@ -426,7 +426,7 @@ extern "C" void app_main()
   }
 
   /* Set the network registration event handler (optional) */
-  modem.setRegistrationEventHandler(myNetworkEventHandler, NULL);
+  modem.setNetworkEventHandler(myNetworkEventHandler, NULL);
 
   /* Set the HTTP event handler */
   modem.setHTTPEventHandler(myHTTPEventHandler, NULL);

--- a/examples/mqtt/main/mqtt.cpp
+++ b/examples/mqtt/main/mqtt.cpp
@@ -361,7 +361,7 @@ extern "C" void app_main()
   }
 
   /* Set the network registration event handler (optional) */
-  modem.setRegistrationEventHandler(myNetworkEventHandler, NULL);
+  modem.setNetworkEventHandler(myNetworkEventHandler, NULL);
 
   /* Set the MQTT event handler */
   modem.setMQTTEventHandler(myMQTTEventHandler, NULL);

--- a/examples/mqtt/main/mqtt.cpp
+++ b/examples/mqtt/main/mqtt.cpp
@@ -203,47 +203,50 @@ bool lteConnect()
 /**
  * @brief The network registration event handler.
  *
- * You can use this handler to get notified of network registration state changes. For this example,
- * we use polling to get the network registration state. You can use this to implement your own
- * reconnection logic.
+ * This function will be called when network registration state changes or when
+ * eDRX parameters are received from the network.
  *
- * @note Make sure to keep this handler as lightweight as possible to avoid blocking the event
- * processing task.
+ * @note Make sure to keep this handler as lightweight as possible to avoid blocking
+ * the event processing task.
  *
- * @param[out] state The network registration state.
+ * @param[out] event The network registration state event.
+ * @param[out] data The registration event data including state and PSM info.
  * @param[out] args User arguments.
  *
  * @return void
  */
-static void myNetworkEventHandler(WalterModemNetworkRegState state, void* args)
+static void myNetworkEventHandler(WMNetworkEventType event, const WMNetworkEventData* data,
+                                  void* args)
 {
-  switch(state) {
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
-    ESP_LOGI(TAG, "Network registration: Registered (home)");
-    break;
+  if(event == WALTER_MODEM_NETWORK_EVENT_REG_STATE_CHANGE) {
+    switch(data->cereg.state) {
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
+      ESP_LOGI(TAG, "Network registration: Registered (home)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
-    ESP_LOGI(TAG, "Network registration: Registered (roaming)");
-    break;
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
+      ESP_LOGI(TAG, "Network registration: Registered (roaming)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Not searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Not searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_DENIED:
-    ESP_LOGI(TAG, "Network registration: Denied");
-    break;
+    case WALTER_MODEM_NETWORK_REG_DENIED:
+      ESP_LOGI(TAG, "Network registration: Denied");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_UNKNOWN:
-    ESP_LOGI(TAG, "Network registration: Unknown");
-    break;
+    case WALTER_MODEM_NETWORK_REG_UNKNOWN:
+      ESP_LOGI(TAG, "Network registration: Unknown");
+      break;
 
-  default:
-    break;
+    default:
+      break;
+    }
   }
 }
 

--- a/examples/mqtts/main/mqtts.cpp
+++ b/examples/mqtts/main/mqtts.cpp
@@ -276,47 +276,50 @@ bool setupTLSProfile(void)
 /**
  * @brief The network registration event handler.
  *
- * You can use this handler to get notified of network registration state changes. For this example,
- * we use polling to get the network registration state. You can use this to implement your own
- * reconnection logic.
+ * This function will be called when network registration state changes or when
+ * eDRX parameters are received from the network.
  *
- * @note Make sure to keep this handler as lightweight as possible to avoid blocking the event
- * processing task.
+ * @note Make sure to keep this handler as lightweight as possible to avoid blocking
+ * the event processing task.
  *
- * @param[out] state The network registration state.
+ * @param[out] event The network registration state event.
+ * @param[out] data The registration event data including state and PSM info.
  * @param[out] args User arguments.
  *
  * @return void
  */
-static void myNetworkEventHandler(WalterModemNetworkRegState state, void* args)
+static void myNetworkEventHandler(WMNetworkEventType event, const WMNetworkEventData* data,
+                                  void* args)
 {
-  switch(state) {
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
-    ESP_LOGI(TAG, "Network registration: Registered (home)");
-    break;
+  if(event == WALTER_MODEM_NETWORK_EVENT_REG_STATE_CHANGE) {
+    switch(data->cereg.state) {
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
+      ESP_LOGI(TAG, "Network registration: Registered (home)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
-    ESP_LOGI(TAG, "Network registration: Registered (roaming)");
-    break;
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
+      ESP_LOGI(TAG, "Network registration: Registered (roaming)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Not searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Not searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_DENIED:
-    ESP_LOGI(TAG, "Network registration: Denied");
-    break;
+    case WALTER_MODEM_NETWORK_REG_DENIED:
+      ESP_LOGI(TAG, "Network registration: Denied");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_UNKNOWN:
-    ESP_LOGI(TAG, "Network registration: Unknown");
-    break;
+    case WALTER_MODEM_NETWORK_REG_UNKNOWN:
+      ESP_LOGI(TAG, "Network registration: Unknown");
+      break;
 
-  default:
-    break;
+    default:
+      break;
+    }
   }
 }
 

--- a/examples/mqtts/main/mqtts.cpp
+++ b/examples/mqtts/main/mqtts.cpp
@@ -434,7 +434,7 @@ extern "C" void app_main()
   }
 
   /* Set the network registration event handler (optional) */
-  modem.setRegistrationEventHandler(myNetworkEventHandler, NULL);
+  modem.setNetworkEventHandler(myNetworkEventHandler, NULL);
 
   /* Set the MQTT event handler */
   modem.setMQTTEventHandler(myMQTTEventHandler, NULL);

--- a/examples/positioning/main/positioning.cpp
+++ b/examples/positioning/main/positioning.cpp
@@ -664,7 +664,7 @@ extern "C" void app_main(void)
   }
 
   /* Set the network registration event handler (optional) */
-  modem.setRegistrationEventHandler(myNetworkEventHandler, NULL);
+  modem.setNetworkEventHandler(myNetworkEventHandler, NULL);
 
   /* Set the Socket event handler */
   modem.setSocketEventHandler(mySocketEventHandler, NULL);

--- a/examples/positioning/main/positioning.cpp
+++ b/examples/positioning/main/positioning.cpp
@@ -248,47 +248,50 @@ bool lteConnect()
 /**
  * @brief The network registration event handler.
  *
- * You can use this handler to get notified of network registration state changes. For this example,
- * we use polling to get the network registration state. You can use this to implement your own
- * reconnection logic.
+ * This function will be called when network registration state changes or when
+ * eDRX parameters are received from the network.
  *
- * @note Make sure to keep this handler as lightweight as possible to avoid blocking the event
- * processing task.
+ * @note Make sure to keep this handler as lightweight as possible to avoid blocking
+ * the event processing task.
  *
- * @param[out] state The network registration state.
+ * @param[out] event The network registration state event.
+ * @param[out] data The registration event data including state and PSM info.
  * @param[out] args User arguments.
  *
  * @return void
  */
-static void myNetworkEventHandler(WalterModemNetworkRegState state, void* args)
+static void myNetworkEventHandler(WMNetworkEventType event, const WMNetworkEventData* data,
+                                  void* args)
 {
-  switch(state) {
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
-    ESP_LOGI(TAG, "Network registration: Registered (home)");
-    break;
+  if(event == WALTER_MODEM_NETWORK_EVENT_REG_STATE_CHANGE) {
+    switch(data->cereg.state) {
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
+      ESP_LOGI(TAG, "Network registration: Registered (home)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
-    ESP_LOGI(TAG, "Network registration: Registered (roaming)");
-    break;
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
+      ESP_LOGI(TAG, "Network registration: Registered (roaming)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Not searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Not searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_DENIED:
-    ESP_LOGI(TAG, "Network registration: Denied");
-    break;
+    case WALTER_MODEM_NETWORK_REG_DENIED:
+      ESP_LOGI(TAG, "Network registration: Denied");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_UNKNOWN:
-    ESP_LOGI(TAG, "Network registration: Unknown");
-    break;
+    case WALTER_MODEM_NETWORK_REG_UNKNOWN:
+      ESP_LOGI(TAG, "Network registration: Unknown");
+      break;
 
-  default:
-    break;
+    default:
+      break;
+    }
   }
 }
 

--- a/examples/tcp/main/tcp.cpp
+++ b/examples/tcp/main/tcp.cpp
@@ -212,47 +212,50 @@ bool lteConnect()
 /**
  * @brief The network registration event handler.
  *
- * You can use this handler to get notified of network registration state changes. For this example,
- * we use polling to get the network registration state. You can use this to implement your own
- * reconnection logic.
+ * This function will be called when network registration state changes or when
+ * eDRX parameters are received from the network.
  *
- * @note Make sure to keep this handler as lightweight as possible to avoid blocking the event
- * processing task.
+ * @note Make sure to keep this handler as lightweight as possible to avoid blocking
+ * the event processing task.
  *
- * @param[out] state The network registration state.
+ * @param[out] event The network registration state event.
+ * @param[out] data The registration event data including state and PSM info.
  * @param[out] args User arguments.
  *
  * @return void
  */
-static void myNetworkEventHandler(WalterModemNetworkRegState state, void* args)
+static void myNetworkEventHandler(WMNetworkEventType event, const WMNetworkEventData* data,
+                                  void* args)
 {
-  switch(state) {
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
-    ESP_LOGI(TAG, "Network registration: Registered (home)");
-    break;
+  if(event == WALTER_MODEM_NETWORK_EVENT_REG_STATE_CHANGE) {
+    switch(data->cereg.state) {
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
+      ESP_LOGI(TAG, "Network registration: Registered (home)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
-    ESP_LOGI(TAG, "Network registration: Registered (roaming)");
-    break;
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
+      ESP_LOGI(TAG, "Network registration: Registered (roaming)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Not searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Not searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_DENIED:
-    ESP_LOGI(TAG, "Network registration: Denied");
-    break;
+    case WALTER_MODEM_NETWORK_REG_DENIED:
+      ESP_LOGI(TAG, "Network registration: Denied");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_UNKNOWN:
-    ESP_LOGI(TAG, "Network registration: Unknown");
-    break;
+    case WALTER_MODEM_NETWORK_REG_UNKNOWN:
+      ESP_LOGI(TAG, "Network registration: Unknown");
+      break;
 
-  default:
-    break;
+    default:
+      break;
+    }
   }
 }
 

--- a/examples/tcp/main/tcp.cpp
+++ b/examples/tcp/main/tcp.cpp
@@ -386,7 +386,7 @@ extern "C" void app_main()
   }
 
   /* Set the network registration event handler (optional) */
-  modem.setRegistrationEventHandler(myNetworkEventHandler, NULL);
+  modem.setNetworkEventHandler(myNetworkEventHandler, NULL);
 
   /* Set the Socket event handler */
   modem.setSocketEventHandler(mySocketEventHandler, NULL);

--- a/examples/udp/main/udp.cpp
+++ b/examples/udp/main/udp.cpp
@@ -212,47 +212,50 @@ bool lteConnect()
 /**
  * @brief The network registration event handler.
  *
- * You can use this handler to get notified of network registration state changes. For this example,
- * we use polling to get the network registration state. You can use this to implement your own
- * reconnection logic.
+ * This function will be called when network registration state changes or when
+ * eDRX parameters are received from the network.
  *
- * @note Make sure to keep this handler as lightweight as possible to avoid blocking the event
- * processing task.
+ * @note Make sure to keep this handler as lightweight as possible to avoid blocking
+ * the event processing task.
  *
- * @param[out] state The network registration state.
+ * @param[out] event The network registration state event.
+ * @param[out] data The registration event data including state and PSM info.
  * @param[out] args User arguments.
  *
  * @return void
  */
-static void myNetworkEventHandler(WalterModemNetworkRegState state, void* args)
+static void myNetworkEventHandler(WMNetworkEventType event, const WMNetworkEventData* data,
+                                  void* args)
 {
-  switch(state) {
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
-    ESP_LOGI(TAG, "Network registration: Registered (home)");
-    break;
+  if(event == WALTER_MODEM_NETWORK_EVENT_REG_STATE_CHANGE) {
+    switch(data->cereg.state) {
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_HOME:
+      ESP_LOGI(TAG, "Network registration: Registered (home)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
-    ESP_LOGI(TAG, "Network registration: Registered (roaming)");
-    break;
+    case WALTER_MODEM_NETWORK_REG_REGISTERED_ROAMING:
+      ESP_LOGI(TAG, "Network registration: Registered (roaming)");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Not searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_NOT_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Not searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_SEARCHING:
-    ESP_LOGI(TAG, "Network registration: Searching");
-    break;
+    case WALTER_MODEM_NETWORK_REG_SEARCHING:
+      ESP_LOGI(TAG, "Network registration: Searching");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_DENIED:
-    ESP_LOGI(TAG, "Network registration: Denied");
-    break;
+    case WALTER_MODEM_NETWORK_REG_DENIED:
+      ESP_LOGI(TAG, "Network registration: Denied");
+      break;
 
-  case WALTER_MODEM_NETWORK_REG_UNKNOWN:
-    ESP_LOGI(TAG, "Network registration: Unknown");
-    break;
+    case WALTER_MODEM_NETWORK_REG_UNKNOWN:
+      ESP_LOGI(TAG, "Network registration: Unknown");
+      break;
 
-  default:
-    break;
+    default:
+      break;
+    }
   }
 }
 

--- a/examples/udp/main/udp.cpp
+++ b/examples/udp/main/udp.cpp
@@ -386,7 +386,7 @@ extern "C" void app_main()
   }
 
   /* Set the network registration event handler (optional) */
-  modem.setRegistrationEventHandler(myNetworkEventHandler, NULL);
+  modem.setNetworkEventHandler(myNetworkEventHandler, NULL);
 
   /* Set the Socket event handler */
   modem.setSocketEventHandler(mySocketEventHandler, NULL);


### PR DESCRIPTION
# Walter Modem Library Release Notes (Arduino/ESP-IDF) v1.5.0

## Breaking Changes

### Event-Driven Architecture Refactor ([#136](https://github.com/QuickSpot/walter-arduino/pull/136))

The library has been modernized with a complete event-driven architecture, replacing the old polling-based approach. This change significantly improves efficiency and code maintainability but requires updates to existing code.

**Key Breaking Changes:**

- **Event Handler Signatures**: All event handlers now use structured event data passed as const pointers. Old handler signatures will not compile. The new pattern is:
  ```cpp
  void handler(WM<Protocol>EventType event, const WM<Protocol>EventData* data, void* args)
  ```
  This applies to Socket, HTTP, MQTT, CoAP, and GNSS protocols.

- **GNSS Assistance Structure**: Changed from named fields to array indexing:
  ```cpp
  // Old (broken): rsp.data.gnssAssistance.almanac.available
  // New: rsp.data.gnssAssistance[WALTER_MODEM_GNSS_ASSISTANCE_TYPE_ALMANAC].available
  ```

**Migration Benefits:**
- Non-blocking, event-driven architecture
- Efficient handling of multiple rapid events
- Consistent API across all protocols
- Rich event metadata (topic, data_len, msg_id, etc.)

See the [migration guide in PR #136](https://github.com/QuickSpot/walter-arduino/pull/136) for detailed examples and complete migration instructions.

## Deprecations

The following still work but generate warnings. Update your code to avoid future removal:

- **Polling Methods**: The following polling methods are deprecated and may not behave as expected. They will compile but generate runtime warnings:
  - `httpDidRing()`, `mqttDidRing()`, `coapDidRing()`, `socketAvailable()`
  - Replace with `*Receive()` calls inside event handlers for reliable behavior

- **Socket API Parameter Order**: `socket_id` is now the first parameter in all socket functions (previously was last or in the middle). Old order still works but logs runtime warnings.

- **Event Registration Methods**: Use `set<Protocol>EventHandler()` instead of `<protocol>SetEventHandler()`. For example:
  - Old: `modem.httpSetEventHandler()` 
  - New: `modem.setHTTPEventHandler()`

- **Status Check Methods**: `httpGetContextStatus()`, `coapGetContextStatus()`, and `getMqttStatus()` are deprecated. Track connection state in your event handlers instead.

## New Features

### Temperature and Voltage Monitoring ([#137](https://github.com/QuickSpot/walter-arduino/pull/137))

Added comprehensive hardware monitoring capabilities for the modem:

**Temperature Monitoring:**
- Configure temperature thresholds and monitoring modes (off/on/emergency-shutdown)
- Query current temperature and status via `getTemperature()`
- Event callbacks for temperature alerts via `setTemperatureEventHandler()`
- New enums: `WalterModemTempMonitorMode`, `WalterModemTempStatus`

**Voltage Monitoring:**
- Configure voltage thresholds, measurement periods, and monitoring modes
- Query current voltage and status via `getVoltage()`
- Event callbacks for voltage alerts via `setVoltageEventHandler()`
- New enums: `WalterModemVoltageMonitorMode`, `WalterModemVoltageStatus`

**Enhanced Examples:**
- Updated bluecherry example with monitoring demonstrations
- JSON payload format for sensor data
- Improved sync error handling with retry logic

### HTTP Header Customization ([#120](https://github.com/QuickSpot/walter-arduino/pull/120))

Added `extra_header_line` parameter to HTTP functions, allowing custom HTTP headers for advanced use cases.

## Bug Fixes

### Socket Race Condition ([#110](https://github.com/QuickSpot/walter-arduino/pull/110))

Fixed a critical race condition that could cause a panic when closing a socket before all data was received. This resolves stability issues in high-throughput scenarios. ([Issue #109](https://github.com/QuickSpot/walter-arduino/issues/109))

### SIM Card ID Retrieval ([#126](https://github.com/QuickSpot/walter-arduino/pull/126))

Fixed incorrect parsing of ICCID and eUICCID values in `getSIMCardID()`:
- ICCID: Now correctly handles 18-22 digit length
- eUICCID (EID): Now correctly parses all 32 digits
- Improved parsing logic to properly extract values from `AT+SQNCCID` response

### HTTP Status Code Type ([#128](https://github.com/QuickSpot/walter-esp-idf/pull/128))

Corrected `httpStatus` type from signed to `uint16_t`, properly representing HTTP status codes from 100-599. ([Issue #127](https://github.com/QuickSpot/walter-esp-idf/issues/127))


## Other Changes

- **socketConfig**: Reduced default connection timeout from 60s to 30s for faster failure detection
- **GNSS Updates**: `gnssUpdateAssistance()` now returns immediately; listen for `WALTER_MODEM_GNSS_EVENT_ASSISTANCE` in event handlers
- **Protocol Connections**: Connection methods return on AT command response, not on full connection establishment. Monitor connection status via event handlers.


## Resources

- Updated examples available in the `/examples` folder
- Full migration guide: [PR #136](https://github.com/QuickSpot/walter-arduino/pull/136)
- API documentation: Check inline doxygen comments