### PR TITLE
Fix to SIM unlock

### DIFF
--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -4709,7 +4709,7 @@ bool WalterModem::unlockSIM(WalterModemRsp* rsp, walterModemCb cb, void* args, c
     return getSIMState(rsp, cb, args);
   }
 
-  _runCmd(arr("AT+CPIN=", _simPIN), "OK", rsp, cb, args);
+  _runCmd(arr("AT+CPIN=", _atStr(_simPIN)), "OK", rsp, cb, args);
   _returnAfterReply();
 }
 


### PR DESCRIPTION
This is a fix to the SIM unlock. The unlockSim function requires the PIN passed as a char*, but it does not work, unless _atStr() is used to add double quotes (") to it.

This pull request implements the fix found in issue: https://github.com/QuickSpot/walter-esp-idf/issues/156