### PR TITLE
fix(mqtt): add missing lteConnect call in mqtts example

### DIFF
--- a/examples/mqtts/main/mqtts.cpp
+++ b/examples/mqtts/main/mqtts.cpp
@@ -449,6 +449,12 @@ extern "C" void app_main()
     ESP_LOGE(TAG, "TLS Profile setup failed");
     return;
   }
+  
+  /* Connect to the cellular network */
+  if(!lteConnect()) {
+    ESP_LOGE(TAG, "Failed to connect to network");
+    return;
+  }
 
   /* Configure the MQTTS client */
   if(modem.mqttConfig((char*) out_buf, MQTTS_USERNAME, MQTTS_PASSWORD, MQTTS_TLS_PROFILE)) {


### PR DESCRIPTION
mqtts example no longer worked since version 1.5.
lteConnect function was missing.