### PR TITLE
fix(WalterModem): restore compilation and esp_driver_uart added to REQUIRES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ idf_component_register(
          "src/proto/WalterMQTT.cpp"
          "src/proto/WalterSocket.cpp"
     INCLUDE_DIRS "src"
-    REQUIRES fatfs esp_partition app_update spi_flash driver vfs
+    REQUIRES fatfs esp_partition app_update spi_flash esp_driver_uart vfs
     PRIV_REQUIRES esp_timer
 )
 

--- a/src/WalterDefines.h
+++ b/src/WalterDefines.h
@@ -90,7 +90,7 @@ const char* _pdpTypeStr(WalterModemPDPType type);
  * @param format The time format to parse. (For example, "%Y-%m-%dT%H:%M:%S")
  * @return The Unix timestamp on success, or -1 on error.
  */
-int64_t strTotime(const char* timeStr, const char* format);
+int64_t strTotime(const char* timeStr, const char* format = "%Y-%m-%dT%H:%M:%S");
 
 /**
  * @brief Convert a unix timestamp to a formatted time string.
@@ -117,7 +117,8 @@ bool timeToStr(uint64_t timestamp, char* buffer, size_t buffer_len,
  * @param max Maximum allowed value (e.g., UINT32_MAX).
  * @return true if conversion was successful; false otherwise.
  */
-bool strToUint32(const char* str, int len, uint32_t* result, int radix, uint32_t max);
+bool strToUint32(const char* str, int len, uint32_t* result, int radix = 10,
+                 uint32_t max = UINT32_MAX);
 
 /**
  * @brief Convert a string into an unsigned 16-bit integer.
@@ -128,7 +129,7 @@ bool strToUint32(const char* str, int len, uint32_t* result, int radix, uint32_t
  * @param radix Conversion radix (e.g., 10).
  * @return true if conversion was successful; false otherwise.
  */
-bool strToUint16(const char* str, int len, uint16_t* result, int radix);
+bool strToUint16(const char* str, int len, uint16_t* result, int radix = 10);
 
 /**
  * @brief Convert a string into an unsigned 8-bit integer.
@@ -139,7 +140,7 @@ bool strToUint16(const char* str, int len, uint16_t* result, int radix);
  * @param radix Conversion radix (e.g., 10).
  * @return true if conversion was successful; false otherwise.
  */
-bool strToUint8(const char* str, int len, uint8_t* result, int radix);
+bool strToUint8(const char* str, int len, uint8_t* result, int radix = 10);
 
 /**
  * @brief Convert a string into an IEEE754 float.

--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -350,7 +350,7 @@ static int64_t _timegm(const struct tm* tm)
  *
  * @return The unix timestamp or -1 on error.
  */
-int64_t strTotime(const char* timeStr, const char* format = "%Y-%m-%dT%H:%M:%S")
+int64_t strTotime(const char* timeStr, const char* format)
 {
   struct tm tm {};
   if(strptime(timeStr, format, &tm) == NULL) {
@@ -409,8 +409,7 @@ bool timeToStr(uint64_t timestamp, char* buffer, size_t buffer_len, const char* 
  *
  * @return True when the conversion was successful, false if the conversion failed.
  */
-bool strToUint32(const char* str, int len, uint32_t* result, int radix = 10,
-                 uint32_t max = UINT32_MAX)
+bool strToUint32(const char* str, int len, uint32_t* result, int radix, uint32_t max)
 {
   size_t l = len == -1 ? strlen(str) : (size_t) len;
 
@@ -453,7 +452,7 @@ bool strToUint32(const char* str, int len, uint32_t* result, int radix = 10,
  *
  * @return True when the conversion was successful, false if the conversion failed.
  */
-bool strToUint16(const char* str, int len, uint16_t* result, int radix = 10)
+bool strToUint16(const char* str, int len, uint16_t* result, int radix)
 {
   uint32_t tmpResult = 0;
 
@@ -477,7 +476,7 @@ bool strToUint16(const char* str, int len, uint16_t* result, int radix = 10)
  *
  * @return True when the conversion was successful, false if the conversion failed.
  */
-bool strToUint8(const char* str, int len, uint8_t* result, int radix = 10)
+bool strToUint8(const char* str, int len, uint8_t* result, int radix)
 {
   uint32_t tmpResult = 0;
 

--- a/src/proto/WalterHTTP.cpp
+++ b/src/proto/WalterHTTP.cpp
@@ -152,8 +152,8 @@ bool WalterModem::httpQuery(int profile_id, const char* uri, WalterModemHttpQuer
 bool WalterModem::httpSend(int profile_id, const char* uri, uint8_t* buf, uint16_t buf_size,
                            WalterModemHttpSendCmd http_send_cmd,
                            WalterModemHttpPostParam http_post_param, char* content_type_buf,
-                           uint16_t content_type_buf_size, const char* extra_header_line = NULL,
-                           WalterModemRsp* rsp = NULL, walterModemCb cb,
+                           uint16_t content_type_buf_size, const char* extra_header_line,
+                           WalterModemRsp* rsp, walterModemCb cb,
                            void* args)
 {
   if(profile_id >= WALTER_MODEM_MAX_HTTP_PROFILES) {


### PR DESCRIPTION
Restores compilation of the component under **ESP-IDF v5.5.2**, which failed to build on the current `main`.

## Changes

- **`src/proto/WalterHTTP.cpp`** - drop the duplicate `= NULL` defaults from the `httpSend` definition; the header keeps them.
- **`src/WalterDefines.h` + `src/WalterModem.cpp`** - relocate the defaults of `strTotime`, `strToUint8/16/32` from the `.cpp` definitions to the header declarations. These compiled before but were inconsistent (defaults only in the `.cpp`); harmonizing keeps them in one place and usable across all TUs.
- **`CMakeLists.txt`** - `REQUIRES ... driver ...` -> `... esp_driver_uart ...`.