### PR TITLE
allow MQTT payloads larger than one response buffer without corrupting the buffer pool

### DIFF
--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -1062,6 +1062,7 @@ WalterModemBuffer* WalterModem::_getFreeBuffer(void)
       chosenBuf = _bufferPool + i;
       chosenBuf->free = false;
       chosenBuf->size = 0;
+      chosenBuf->rawChunk = false;
 
       break;
     }
@@ -1099,18 +1100,55 @@ void WalterModem::_addATByteToBuffer(char data, bool raw)
 
 void WalterModem::_addATBytesToBuffer(const char* data, size_t length)
 {
-  /* Try to get a free buffer if not already set */
-  if(_parserData.buf == NULL) {
-    _parserData.buf = _getFreeBuffer();
-  }
+  while(length > 0) {
+    /* Try to get a free buffer if not already set */
+    if(_parserData.buf == NULL) {
+      _parserData.buf = _getFreeBuffer();
+    }
 
-  /* If still NULL, drop data silently */
-  if(_parserData.buf == NULL) {
+    /* If still NULL, drop data silently */
+    if(_parserData.buf == NULL) {
+      return;
+    }
+
+    size_t capacity = WALTER_MODEM_RSP_BUF_SIZE - _parserData.buf->size;
+    if(length <= capacity) {
+      memcpy(&_parserData.buf->data[_parserData.buf->size], data, length);
+      _parserData.buf->size += length;
+      return;
+    }
+
+    /* The data does not fit in the current buffer. This only happens for payload responses
+     * larger than one buffer (e.g. +SQNSMQTTRCVMESSAGE): fill the buffer completely, flush it
+     * to the response processor as a raw chunk and continue in a fresh buffer. Without the
+     * flush the memcpy would overflow the fixed-size buffer and corrupt the pool. */
+    memcpy(&_parserData.buf->data[_parserData.buf->size], data, capacity);
+    _parserData.buf->size += capacity;
+    data += capacity;
+    length -= capacity;
+    _flushRawChunk();
+  }
+}
+
+void WalterModem::_flushRawChunk()
+{
+  WalterModemBuffer* buf = _parserData.buf;
+  if(buf == NULL || buf->size == 0) {
     return;
   }
 
-  memcpy(&_parserData.buf->data[_parserData.buf->size], data, length);
-  _parserData.buf->size += length;
+  /* The first chunk of a payload still starts with the response's leading CRLF framing: strip it
+   * here because the response processor must not CRLF-trim raw chunks (bytes at a chunk boundary
+   * may legitimately be CR/LF payload data). */
+  if(_parserData.flushedPayloadSize == 0 && buf->size >= 2 && buf->data[0] == '\r' &&
+     buf->data[1] == '\n') {
+    memmove(buf->data, buf->data + 2, buf->size - 2);
+    buf->size -= 2;
+  }
+
+  buf->rawChunk = true;
+  _parserData.flushedPayloadSize += buf->size;
+  _queueRxBuffer();
 }
 
 void WalterModem::_queueRxBuffer()
@@ -1329,12 +1367,19 @@ bool WalterModem::_expectingPayload()
     }
     if(sizeStr[0] != '\0') {
       _receivedPayloadSize = atoi(sizeStr);
-      if(_receivedPayloadSize >= dataSize) {
+      /* Payloads larger than one buffer are partially flushed to the response processor as raw
+       * chunks: the completion accounting must be cumulative across those flushes. */
+      size_t receivedSoFar = _parserData.flushedPayloadSize + dataSize;
+      if(_receivedPayloadSize >= receivedSoFar) {
         // Incomplete payload received so far
-        _receivedPayloadSize -= dataSize;
+        _receivedPayloadSize -= receivedSoFar;
       } else {
         // Complete payload already received - no more bytes expected
         _receivedPayloadSize = 0;
+        if(_parserData.flushedPayloadSize > 0) {
+          /* The buffer about to be queued is the tail of a partially flushed payload */
+          _parserData.payloadTail = true;
+        }
         return false;
       }
       return true;
@@ -1361,12 +1406,19 @@ bool WalterModem::_expectingPayload()
       }
       if(sizeStr[0] != '\0') {
         _receivedPayloadSize = atoi(sizeStr);
-        if(_receivedPayloadSize >= dataSize) {
+        /* Payloads larger than one buffer are partially flushed to the response processor as raw
+         * chunks: the completion accounting must be cumulative across those flushes. */
+        size_t receivedSoFar = _parserData.flushedPayloadSize + dataSize;
+        if(_receivedPayloadSize >= receivedSoFar) {
           // Incomplete payload received so far
-          _receivedPayloadSize -= dataSize;
+          _receivedPayloadSize -= receivedSoFar;
         } else {
           // Complete payload already received - no more bytes expected
           _receivedPayloadSize = 0;
+          if(_parserData.flushedPayloadSize > 0) {
+            /* The buffer about to be queued is the tail of a partially flushed payload */
+            _parserData.payloadTail = true;
+          }
           return false;
         }
         return true;
@@ -1446,6 +1498,22 @@ void WalterModem::_parseRxData(char* rx_data, size_t rx_len)
         continue;
       } else {
         _receivingPayload = false;
+        if(_parserData.payloadTail) {
+          /* Tail of a payload that was partially flushed as raw chunks: strip the trailing CRLF
+           * framing here and mark the buffer raw, so the response processor does not CRLF-trim
+           * payload bytes at the chunk boundary. */
+          _parserData.payloadTail = false;
+          _parserData.flushedPayloadSize = 0;
+          if(_parserData.buf->size >= 2 &&
+             _parserData.buf->data[_parserData.buf->size - 2] == '\r' &&
+             _parserData.buf->data[_parserData.buf->size - 1] == '\n') {
+            _parserData.buf->size -= 2;
+          }
+          _parserData.buf->rawChunk = true;
+        } else {
+          /* Any complete non-payload message ends a (possibly abandoned) raw-chunk accumulation */
+          _parserData.flushedPayloadSize = 0;
+        }
         /* Finally, queue the buffer if we are sure the message is complete */
         _queueRxBuffer();
       }
@@ -1682,6 +1750,7 @@ WalterModemCmd* WalterModem::_queueModemCMD(
   cmd->completeHandlerArg = completeHandlerArg;
   cmd->payload = payload;
   cmd->payloadSize = payloadSize;
+  cmd->payloadReceived = 0;
   cmd->maxAttempts = maxAttempts;
   cmd->atRspLen = atRsp == NULL ? 0 : strlen(atRsp);
   cmd->state = WALTER_MODEM_CMD_STATE_NEW;
@@ -1812,15 +1881,19 @@ void WalterModem::_processModemRSP(WalterModemCmd* cmd, WalterModemBuffer* buff)
   }
 #endif
 
-  // Skip leading \r\n if present
-  if(buff->size >= 2 && buff->data[0] == '\r' && buff->data[1] == '\n') {
-    memmove(buff->data, buff->data + 2, buff->size - 2);
-    buff->size -= 2;
-  }
+  /* Raw payload chunks carry no CRLF framing (stripped by the parser at flush time) and must not
+   * be trimmed: bytes at a chunk boundary may legitimately be CR/LF payload data. */
+  if(!buff->rawChunk) {
+    // Skip leading \r\n if present
+    if(buff->size >= 2 && buff->data[0] == '\r' && buff->data[1] == '\n') {
+      memmove(buff->data, buff->data + 2, buff->size - 2);
+      buff->size -= 2;
+    }
 
-  // Skip trailing \r\n if present
-  if(buff->size >= 2 && buff->data[buff->size - 2] == '\r' && buff->data[buff->size - 1] == '\n') {
-    buff->size -= 2;
+    // Skip trailing \r\n if present
+    if(buff->size >= 2 && buff->data[buff->size - 2] == '\r' && buff->data[buff->size - 1] == '\n') {
+      buff->size -= 2;
+    }
   }
 
   WalterModemState result = WALTER_MODEM_STATE_OK;
@@ -3496,14 +3569,20 @@ void WalterModem::_processModemRSP(WalterModemCmd* cmd, WalterModemBuffer* buff)
    * sent command is a MQTT receive message command.
    */
   if(cmd && cmd->atCmd[0] && !strcmp(cmd->atCmd[0], "AT+SQNSMQTTRCVMESSAGE=0,") &&
-     cmd->rsp->type != WALTER_MODEM_RSP_DATA_TYPE_MQTT) {
-
-    const char* rspStr = _buffStr(buff);
+     (cmd->rsp->type != WALTER_MODEM_RSP_DATA_TYPE_MQTT || buff->rawChunk)) {
 
     cmd->rsp->type = WALTER_MODEM_RSP_DATA_TYPE_MQTT;
 
     if(cmd->payload) {
-      memcpy(cmd->payload, rspStr, cmd->payloadSize);
+      /* Payloads larger than one buffer arrive as multiple raw chunks: accumulate them at the
+       * received offset. The copy is bounded by both the chunk size and the caller's buffer,
+       * which also fixes the single-buffer case reading past the response buffer when the
+       * payload is shorter than the requested size. */
+      size_t remaining =
+          (cmd->payloadSize > cmd->payloadReceived) ? cmd->payloadSize - cmd->payloadReceived : 0;
+      size_t chunkSize = (buff->size < remaining) ? buff->size : remaining;
+      memcpy(cmd->payload + cmd->payloadReceived, buff->data, chunkSize);
+      cmd->payloadReceived += chunkSize;
     }
 
     goto after_processing_logic;

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -2932,6 +2932,15 @@ typedef struct {
    * not in use and can be used to store the next response in.
    */
   volatile bool free = true;
+
+  /**
+   * @brief This flag is set to true when the buffer holds a raw chunk of a payload response that
+   * spans multiple buffers (e.g. an +SQNSMQTTRCVMESSAGE payload larger than one buffer). Raw
+   * chunks carry no CRLF framing (it is stripped by the parser at flush time) and must not be
+   * CRLF-trimmed by the response processor: bytes at a chunk boundary may legitimately be CR/LF
+   * payload data.
+   */
+  bool rawChunk = false;
 } WalterModemBuffer;
 
 /**
@@ -2964,6 +2973,13 @@ typedef struct sWalterModemCmd {
    * @brief The number of bytes in the payload buffer.
    */
   uint16_t payloadSize;
+
+  /**
+   * @brief The number of payload bytes already copied into the payload buffer while processing a
+   * payload response that spans multiple buffers (e.g. an +SQNSMQTTRCVMESSAGE payload larger than
+   * one buffer). Reset when the command is queued.
+   */
+  uint16_t payloadReceived = 0;
 
   /**
    * @brief The expected command response starting string.
@@ -3084,6 +3100,20 @@ typedef struct {
    * @brief In raw data chunk parser state, we remember nr expected bytes
    */
   size_t rawChunkSize = 0;
+
+  /**
+   * @brief The number of payload bytes already flushed to the response processor as raw chunks
+   * for the in-flight payload response (payloads larger than one buffer). 0 when no flush has
+   * happened; used to make the payload-completion accounting cumulative across buffers.
+   */
+  size_t flushedPayloadSize = 0;
+
+  /**
+   * @brief Set when _expectingPayload() detects the completion of a payload that was partially
+   * flushed as raw chunks: the buffer about to be queued is the payload's tail and must have its
+   * trailing CRLF framing stripped and be marked as a raw chunk before queueing.
+   */
+  bool payloadTail = false;
 } walter_modem_at_parser_data_t;
 
 /**
@@ -3733,6 +3763,16 @@ private:
    * @return None.
    */
   static void _addATBytesToBuffer(const char* data, size_t length);
+
+  /**
+   * @brief Flush the parser's current buffer to the response processor as a raw payload chunk.
+   *
+   * Called when a payload response outgrows a single buffer from the pool: the full buffer is
+   * queued (marked as a raw chunk, with the response's leading CRLF framing stripped on the first
+   * chunk) so the response processor can accumulate the payload, and parsing continues in a fresh
+   * buffer. Without this, appending would overflow the fixed-size buffer and corrupt the pool.
+   */
+  static void _flushRawChunk();
 
   /**
    * @brief Copy the currently received data buffer into the task queue.


### PR DESCRIPTION
## The Problem

Receiving an MQTT message larger than ~1536 bytes over the AT interface permanently kills the modem task. On our hardware (Walter, Sequans LR8.2.1.0-61488, LTE-M, MQTTS broker) a subscribed 2048-byte single-line JSON message reproducibly ends all AT processing: no further URCs, no command completions, every subsequent `WalterModem` call blocks forever. Only a reset recovers the device. Messages of 1536 bytes and below work perfectly.

## Root cause

`_addATBytesToBuffer()` appends into the current pool buffer with an unbounded `memcpy`:

```cpp
memcpy(&_parserData.buf->data[_parserData.buf->size], data, length);
_parserData.buf->size += length;
```

`WalterModemBuffer::data` is `WALTER_MODEM_RSP_BUF_SIZE` (1540) bytes. An `AT+SQNSMQTTRCVMESSAGE` response is `\r\n<payload>\r\n` followed by `\r\nOK\r\n` — for a payload with no interior CR/LF, the parser finds no line boundary and keeps appending until the buffer overflows. The overflow first smashes the buffer's own `size` field (which immediately follows `data` in the struct), so subsequent appends land at garbage offsets which corrupts adjacent pool entries and parser state. The exact boundary matches the framing: leading `\r\n` + payload + trailing `\r\n` ≤ 1540 → payload ≤ **1536** bytes.

Two smaller adjacent issues:

- the RCVMESSAGE completion copy `memcpy(cmd->payload, rspStr, cmd->payloadSize)` reads past the response buffer whenever the delivered payload is shorter than `payloadSize`;
- `_buffStr()` writes its 0-terminator at `data[size]`, which is out of bounds for an exactly-full buffer.

DEBUG trace of the failure below.  It's the last output the device ever produces.  The RX print shows partial payload, then bytes spliced in from neighboring pool memory, then NULs):

```sh
[D] TX: AT+SQNSMQTTRCVMESSAGE=0,"<topic>",1,2048
[D] RX: \r\n{"id":"probe-2048",... <payload bytes> ... \x98 ",1,12,,,"","",0,1,0\r\n\r\n\0\0\0\0...
(no further output, modem task dead)
```

For comparison, a 1536-byte payload arrives as a single buffer filled to exactly 1540 bytes and works.

## Fix

Payload responses larger than one buffer are now delivered to the response processor as a sequence of buffers instead of overflowing one:

- `_addATBytesToBuffer()` bounds every append; when a payload outgrows the buffer, the full buffer is flushed to the processor as a **raw chunk** (`WalterModemBuffer::rawChunk`) and parsing continues in a fresh buffer (`_flushRawChunk()`).
- Raw chunks carry no CRLF framing — the parser strips the leading `\r\n` on the first chunk at flush time and the trailing `\r\n` on the tail chunk at queue time — and the processor skips its CRLF trimming for them, since bytes at a chunk boundary may legitimately be CR/LF payload data.
- `_expectingPayload()`'s completion accounting for `AT+SQNSMQTTRCVMESSAGE`/`AT+SQNHTTPRCV` is cumulative across flushed chunks (`_parserData.flushedPayloadSize`).
- The RCVMESSAGE response branch in `_processModemRSP()` accumulates chunks into `cmd->payload` at a tracked offset (`cmd->payloadReceived`), bounded by both the chunk size and the caller's buffer — which also fixes the pre-existing over-read for short payloads.

Responses that fit one buffer (≤1536-byte payloads and every normal AT response/URC) take exactly the same path as before — no flush is triggered and the processor's behavior is unchanged.

## Our Validation Tests (on hardware)

Walter board, Sequans LR8.2.1.0-61488, LTE-M (roaming), MQTTS broker, QoS 1, subscribed wildcard topic; payloads are single-line JSON fetched with `mqttReceive(topic, mid, buf, <message length>)`:

| Payload           | Before                                       | After                    |
| ----------------- | -------------------------------------------- | ------------------------ |
| 1536 B (boundary) | delivered                                    | delivered                |
| 2048 B            | **modem task dead, device dead until reset** | delivered, parsed, acked |
| 2265 B            | untestable (immediately dead)                | delivered, parsed, acked |
| 3072 B            | untestable (immediately dead)                | delivered, parsed, acked |

3072 B was the largest size we tested end-to-end (our broker caps total packet size at 4096). The chunking loop is size-agnostic.  3072 B arrives as two full raw chunks plus a tail, and `mqttReceive` itself caps requests at the modem's 4096-byte message limit.)

The DEBUG trace after the fix shows the 2048-byte payload arriving as a 1538-byte raw chunk plus a 510-byte tail, followed by the `OK` completing the command.

## Notes

- `AT+SQNHTTPRCV` shares the parser-side fix (bounded appends + cumulative accounting), but its response-processor branch was not changed and large HTTP payloads were not tested on hardware.  Happy to follow up if useful.
- The fragility of URCs interleaving with RCVMESSAGE responses is unchanged.  Chunked payloads are exactly as susceptible as single-buffer ones were.
- The completion accounting still trusts the length parameter of the AT command, as before.  Callers pass the ring-advertised message length (as the examples do).

I'm going to be continuing to run/test this branch in my own device dev builds since this unblocks our use case that required the full hardware-supported message size.  If you need any changes or want me to test anything else specifically, let me know!